### PR TITLE
Fix deprecated (as of Rails 3) use of routes => match becomes get

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Teabag::Engine.routes.draw do
-  match "/fixtures/*filename", to: "spec#fixtures", via: :get
-  match "/(:suite)", to: "spec#index", via: :get, defaults: { suite: "default" }
+  get "/fixtures/*filename", to: "spec#fixtures", via: :get
+  get "/(:suite)", to: "spec#index", via: :get, defaults: { suite: "default" }
 end


### PR DESCRIPTION
In the Rails 4.0.0.beta using match in routes.rb raises an error.  It was deprecated in Rails 3.

```
You should not use the `match` method in your router without specifying an HTTP method. (RuntimeError)
If you want to expose your action to GET, use `get` in the router:

  Instead of: match "controller#action"
  Do: get "controller#action"
```
