### PR TITLE
Use a more up-to-date Phantomjs gem.

### DIFF
--- a/lib/teabag/drivers/phantomjs_driver.rb
+++ b/lib/teabag/drivers/phantomjs_driver.rb
@@ -10,7 +10,7 @@ module Teabag
       def run_specs(suite, url)
         runner = Teabag::Runner.new(suite)
 
-        Phantomjs.instance_variable_set(:@executable, executable)
+        Phantomjs.instance_variable_set(:@path, executable)
         Phantomjs.run(script, url) do |line|
           runner.process(line)
         end

--- a/teabag.gemspec
+++ b/teabag.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.executables = "teabag"
 
   s.add_dependency "railties", [">= 3.2.5","< 5"]
-  s.add_dependency "phantomjs.rb", "~> 0.0.5"
+  s.add_dependency "phantomjs", ">= 1.8.1.1"
 end


### PR DESCRIPTION
Switch to https://github.com/colszowka/phantomjs-gem for the Phantomjs gem. It installs a more recent version of the binaries (1.8 vs 1.6), and now supports the .run() API that teabag uses.
