### PR TITLE
Proposed method to force inclusion of appliction.js.

### DIFF
--- a/app/views/teabag/spec/runner.html.erb
+++ b/app/views/teabag/spec/runner.html.erb
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, user-scalable=no">
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag_for_teabag *@suite.stylesheets %>
+    <%= javascript_include_tag "application" %>
     <%= javascript_include_tag_for_teabag *@suite.core_javascripts %>
     <script type="text/javascript">
       // pass relevant info to javascript


### PR DESCRIPTION
I'm hoping I just don't understand some of the loading and configuration. I've uncommented

```
require application
```

in the spec_helper.coffee, and the require appears in the browser inspector, but does
not seem to work. This little patch to the runner view fixes both the web page and
headless run for me.

@jejacks0n
