### PR TITLE
Skip coverage of vendored and gemmed assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,9 +314,10 @@ end
 </dd>
 
 <dt> no_coverage </dt><dd>
-  If you're running coverage reports you may want to exclude libraries like jQuery, or support libraries that you're not testing. Accepts an array of filenames or regular expressions. For example, to remove jQuery use "jquery.min.js" etc.<br/><br/>
+  When running coverage reports, you probably want to exclude libraries that you're not testing.
+  Accepts an array of filenames or regular expressions. The default is to exclude assets from vendors or gems.<br/><br/>
 
-  <b>default:</b> <code>`[%r{/support/}, %r{/(.+)_helper.}]`</code>
+  <b>default:</b> <code>`[%r{/lib/ruby/gems/}, %r{/vendor/assets/}, %r{/support/}, %r{/(.+)_helper.}]`</code>
 </dd>
 
 </dl>
@@ -457,7 +458,7 @@ These configuration directives are applicable only when running via the rake tas
   </ul>
 </dd>
 
-<dt> coverage </dt><dd>
+<dt> coverage_reports </dt><dd>
   Specify which code coverage reports instanbul should generate.<br/><br/>
 
   <b>available:</b> text-summary, text, html, lcov, lcovonly, cobertura<br/>

--- a/lib/generators/teabag/install/templates/jasmine/initializer.rb
+++ b/lib/generators/teabag/install/templates/jasmine/initializer.rb
@@ -48,9 +48,9 @@ Teabag.setup do |config|
     # stylesheet for the HTML reporter.
     suite.stylesheets = ["teabag"]
 
-    # If you're running coverage reports you may want to exclude libraries like jQuery, or support libraries that you're
-    # not testing. Accepts an array of filenames or regular expressions.
-    suite.no_coverage = [%r{/support/}, %r{/(.+)_helper.}]
+    # When running coverage reports, you probably want to exclude libraries that you're not testing.
+    # Accepts an array of filenames or regular expressions. The default is to exclude assets from vendors or gems.
+    suite.no_coverage = [%r{/lib/ruby/gems/}, %r{/vendor/assets/}, %r{/support/}, %r{/(.+)_helper.}]
     # suite.no_coverage << "jquery.min.js" # excludes jquery from coverage reports
 
   end

--- a/lib/generators/teabag/install/templates/mocha/initializer.rb
+++ b/lib/generators/teabag/install/templates/mocha/initializer.rb
@@ -48,9 +48,9 @@ Teabag.setup do |config|
     # stylesheet for the HTML reporter.
     suite.stylesheets = ["teabag"]
 
-    # If you're running coverage reports you may want to exclude libraries like jQuery, or support libraries that you're
-    # not testing. Accepts an array of filenames or regular expressions.
-    suite.no_coverage = [%r{/support/}, %r{/(.+)_helper.}]
+    # When running coverage reports, you probably want to exclude libraries that you're not testing.
+    # Accepts an array of filenames or regular expressions. The default is to exclude assets from vendors or gems.
+    suite.no_coverage = [%r{/lib/ruby/gems/}, %r{/vendor/assets/}, %r{/support/}, %r{/(.+)_helper.}]
     # suite.no_coverage << "jquery.min.js" # excludes jquery from coverage reports
 
   end

--- a/lib/generators/teabag/install/templates/qunit/initializer.rb
+++ b/lib/generators/teabag/install/templates/qunit/initializer.rb
@@ -48,9 +48,9 @@ Teabag.setup do |config|
     # stylesheet for the HTML reporter.
     suite.stylesheets = ["teabag"]
 
-    # If you're running coverage reports you may want to exclude libraries like jQuery, or support libraries that you're
-    # not testing. Accepts an array of filenames or regular expressions.
-    suite.no_coverage = [%r{/support/}, %r{/(.+)_helper.}]
+    # When running coverage reports, you probably want to exclude libraries that you're not testing.
+    # Accepts an array of filenames or regular expressions. The default is to exclude assets from vendors or gems.
+    suite.no_coverage = [%r{/lib/ruby/gems/}, %r{/vendor/assets/}, %r{/support/}, %r{/(.+)_helper.}]
     # suite.no_coverage << "jquery.min.js" # excludes jquery from coverage reports
 
   end


### PR DESCRIPTION
I'm digging the instrumentation from #31, but my reports are full of
stats on gemmed assets (e.g.
`.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/backbone-on-rails-1.0.0.0/vendor/assets/javascripts/`).

This patch omits non-app assets by default (i.e. any in gems or
`vendor/assets`).
