### PR TITLE
Fix incorrect content length for the instrumented source

### DIFF
--- a/lib/teabag/instrumentation.rb
+++ b/lib/teabag/instrumentation.rb
@@ -28,7 +28,7 @@ module Teabag
       status, headers, @asset = response
       headers, @asset = [headers.clone, @asset.clone]
       result = process_and_instrument
-      length = result.length.to_s
+      length = result.bytesize.to_s
 
       headers["Content-Length"] = length
       @asset.instance_variable_set(:@source, result)


### PR DESCRIPTION
The original code  used String#length, which returns the length of the string in characters, but the header must be the length of the string in bytes. This was causing errors because the browser was (presumably) truncating the content after receiving a (lower) specific number of bytes than the actual number of bytes in the content.
