### PR TITLE
use File#write instead of File::write that isn't supported by ruby-1.9.2

### DIFF
--- a/lib/teabag/coverage.rb
+++ b/lib/teabag/coverage.rb
@@ -9,7 +9,7 @@ module Teabag
     def reports
       Dir.mktmpdir do |path|
         input = File.join(path, 'coverage.json')
-        File.write(input, @data.to_json)
+        File.open(input, 'w') { |file| file.write(@data.to_json) }
         results = []
         for format in Teabag.configuration.coverage_reports
           result = generate_report(input, format)

--- a/lib/teabag/instrumentation.rb
+++ b/lib/teabag/instrumentation.rb
@@ -44,7 +44,7 @@ module Teabag
       Dir.mktmpdir do |path|
         filename = File.basename(file)
         input = File.join(path, filename).sub(/\.js.+/, ".js")
-        File.write(input, @asset.source)
+        File.open(input, 'w') { |file| file.write(@asset.source) }
 
         instrument(input).gsub(input, file)
       end

--- a/spec/teabag/coverage_spec.rb
+++ b/spec/teabag/coverage_spec.rb
@@ -10,7 +10,7 @@ describe Teabag::Coverage do
     before do
       Teabag.configuration.should_receive(:coverage_reports).and_return(["text", "text-summary", "html"])
       subject.stub(:generate_report) { |i, f| "_#{f}_report_" }
-      File.stub(:write)
+      File.stub(:open)
 
       path = nil
       Dir.mktmpdir { |p| path = p }
@@ -19,7 +19,9 @@ describe Teabag::Coverage do
     end
 
     it "writes the data to a file" do
-      File.should_receive(:write).with(@output, '{"foo":"bar"}')
+      file = mock('file')
+      File.should_receive(:open).with(@output, "w").and_yield(file)
+      file.should_receive(:write).with('{"foo":"bar"}')
       subject.reports
     end
 

--- a/spec/teabag/instrumentation_spec.rb
+++ b/spec/teabag/instrumentation_spec.rb
@@ -72,7 +72,7 @@ describe Teabag::Instrumentation do
     before do
       Teabag::Instrumentation.stub(:add?).and_return(true)
 
-      File.stub(:write)
+      File.stub(:open)
       subject.any_instance.stub(:instrument).and_return(source + " // instrumented")
 
       path = nil
@@ -82,7 +82,9 @@ describe Teabag::Instrumentation do
     end
 
     it "writes the file to a tmp path" do
-      File.should_receive(:write).with(@output, "function add(a, b) { return a + b } // ☃ ")
+      file = mock('file')
+      File.should_receive(:open).with(@output, "w").and_yield(file)
+      file.should_receive(:write).with("function add(a, b) { return a + b } // ☃ ")
       subject.add_to(response, env)
     end
 


### PR DESCRIPTION
File::write is not supported by ruby-1.9.2. 
Changing code like 
File.write(filename, file_content) 
to 
File.open(filename, 'w') { |file| file.write(file_content) } 
will solve the problem and still work for higher ruby versions.

We didn't experience any other issues while using teabag with ruby-1.9.2 (we are using capybara 2.0.3). But maybe if you don't plan to support ruby-1.9.2, it should be specified in the docs.
