### PR TITLE
Not using requirejs-rails throws an exception when running test suite

### DIFF
--- a/app/views/teabag/spec/runner.html.erb
+++ b/app/views/teabag/spec/runner.html.erb
@@ -20,7 +20,7 @@
       Teabag.onWindowLoad(function () {
         //setup the Teabag path prefix to load /assets
         require.config(
-            <% if Rails.application.config.requirejs %>
+            <% if Rails.application.config.respond_to?('requirejs') %>
               <%= Rails.application.config.requirejs.user_config.merge({baseUrl: '/assets'}).to_json.html_safe %>
             <% else %>
               {


### PR DESCRIPTION
When you run the test suite and you aren't using the requirejs-rails gem, it throws a ruby error and you cannot get to the specs. The code to check if requirejs is in the config, instead just throws a method error. Fix is to add a responds_to?
