### PR TITLE
Fixed URL generation

### DIFF
--- a/lib/teaspoon/console.rb
+++ b/lib/teaspoon/console.rb
@@ -72,11 +72,12 @@ module Teaspoon
       parts = []
       parts << "grep=#{URI::encode(@options[:filter])}" if @options[:filter].present?
       (@suites[suite] || @files).each { |file| parts << "file[]=#{URI::encode(file)}" }
-      "?#{parts.join('&')}" if parts.present?
+      "#{parts.join('&')}" if parts.present?
     end
 
     def url(suite)
-      ["#{@server.url}#{Teaspoon.configuration.mount_at}", suite, filter(suite)].compact.join("/")
+      base_url = ["#{@server.url}#{Teaspoon.configuration.mount_at}", suite].join('/')
+      [base_url, filter(suite)].compact.join('?')
     end
   end
 end

--- a/spec/teaspoon/console_spec.rb
+++ b/spec/teaspoon/console_spec.rb
@@ -66,7 +66,7 @@ describe Teaspoon::Console do
 
       suites = subject.send(:suites)
       expect(suites).to eq(["foo"])
-      expect(subject.send(:filter, "foo")).to eq("?file[]=file2")
+      expect(subject.send(:filter, "foo")).to eq("file[]=file2")
     end
 
     it "runs the tests" do


### PR DESCRIPTION
Previously generated URLs looked like

```
http://127.0.0.1:60307/teaspoon/default/?file[]=/Users/...
```

which caused problems because /default/?... is actually not recognized while /default?... is with the routing config:

```
get "/:suite", to: "spec#runner", defaults: { suite: "default" }
```
