### PR TITLE
Coverage reports are not generated when use_require is true

### DIFF
--- a/app/views/teaspoon/spec/runner.html.erb
+++ b/app/views/teaspoon/spec/runner.html.erb
@@ -13,7 +13,7 @@
     Teaspoon.suites = <%=raw @suite.suites.to_json %>;
   </script>
   <% if @suite.use_require %>
-    <%= javascript_include_tag_for_teaspoon *@suite.helper %>
+    <%= javascript_include_tag_for_teaspoon *@suite.helper, @javascript_options %>
     <script type="text/javascript">
       // When the DOM is loaded, we then use require to include currently selected file/suite, then once those are all loaded, we run Teaspoon
       // @suite.spec_javascripts_for_require strips off the .js and adds the Teaspoon prefix


### PR DESCRIPTION
It looks like the @javascript_options are only passed to javascript_include_tag_for_teaspoon when not using require. As a result, none of the JS files have ?instrument=1 appended to the URL and so aren't instrumented for coverage.
