### PR TITLE
Check for blank lines when using the Phantomjs driver

### DIFF
--- a/lib/teaspoon/drivers/phantomjs_driver.rb
+++ b/lib/teaspoon/drivers/phantomjs_driver.rb
@@ -13,7 +13,7 @@ module Teaspoon
         Phantomjs.instance_variable_set(:@path, executable)
         # Phantomjs.run takes the command-line args as an array, so if we need to pass in switches/flags, need to split on space
         Phantomjs.run(*([driver_cli_options && driver_cli_options.split(" "), script, url].flatten.compact)) do |line|
-          runner.process(line)
+          runner.process(line) if line && line.strip != ""
         end
 
         runner.failure_count


### PR DESCRIPTION
Sometimes phantomjs emits a blank line at the end of running, which breaks the Teaspoon driver (because it tries to parse it as JSON, resulting in a nil object).  This is a simple fix to ignore any blank lines.
