### PR TITLE
Fix command line runner crash when 

### DIFF
--- a/lib/teaspoon/runner.rb
+++ b/lib/teaspoon/runner.rb
@@ -36,7 +36,7 @@ module Teaspoon
 
     def output_from(line)
       json = JSON.parse(line)
-      return false unless json["_teaspoon"] && json["type"]
+      return false unless json && json["_teaspoon"] && json["type"]
       result = Teaspoon::Result.build_from_json(json)
       notify_formatters result
       @failure_count += 1 if result.failing?


### PR DESCRIPTION
Very small fix, I was getting a crash when using the phantomjs driver.The cause seemed to be that after the final spec json, the Phantomjs run was yielding an empty string to runner.process, resulting in an exception in output_from, so I added a nil check.
