### PR TITLE
Use HTML5 doctype to prevent Firefox from running tests in quirks mode.

### DIFF
--- a/app/views/teaspoon/spec/runner.html.erb
+++ b/app/views/teaspoon/spec/runner.html.erb
@@ -1,4 +1,4 @@
-<!DOCTYPE>
+<!DOCTYPE html>
 <html>
 <head>
   <title>Teaspoon :: Javascript Test Runner</title>

--- a/app/views/teaspoon/spec/suites.html.erb
+++ b/app/views/teaspoon/spec/suites.html.erb
@@ -1,4 +1,4 @@
-<!DOCTYPE>
+<!DOCTYPE html>
 <html>
   <head>
     <title>Teaspoon :: Suites</title>


### PR DESCRIPTION
I ran into an issue where Firefox was running tests in quirks mode due to the incomplete doctype. Running in quirks mode causes some subtle things to break (such as `$(window).height()` always returning 0 regardless of the actual window height).

This patch adds an HTML5 doctype to the runner views so tests are always executed in standards mode.
