### PR TITLE
Allows when using the requirejs partial to override the baseUrl. Fixes #87

### DIFF
--- a/app/views/teaspoon/spec/_require_js.html.erb
+++ b/app/views/teaspoon/spec/_require_js.html.erb
@@ -8,7 +8,7 @@
       <% if Rails.application.config.respond_to?(:requirejs) %>
         <%=raw Rails.application.config.requirejs.user_config.merge({baseUrl: '/assets'}).to_json %>
       <% else %>
-        {baseUrl: '/assets'}
+        {baseUrl: Teaspoon.config.baseUrl || '/assets'}
       <% end %>
     );
 


### PR DESCRIPTION
I had the same issue as #87.

in my suite config i just add to make it work.

``` ruby
config.suite :raja do |suite|
  suite.js_config = {:baseUrl => '/assets/raja'}
```
