### PR TITLE
support coverage output dir option to choose where coverage reports shou...

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,8 +534,18 @@ These configuration directives are applicable only when running via the rake tas
   </ul>
 </dd>
 
-</dl>
+<dt> coverage_output_dir </dt><dd>
+  Specify directory where coverage reports should be generated.<br/><br/>
 
+  <b>default:</b> <code>"coverage"</code>
+
+  <ul>
+    <li>CLI: -O, --coverage-output-dir DIR</li>
+    <li>ENV: COVERAGE_OUTPUT_DIR=coverage</li>
+  </ul>
+</dd>
+
+</dl>
 
 ## Test Frameworks
 

--- a/lib/generators/teaspoon/install/templates/env.rb
+++ b/lib/generators/teaspoon/install/templates/env.rb
@@ -14,20 +14,21 @@ require File.expand_path("../../config/environment", __FILE__)
 # rake teaspoon DRIVER=selenium SUPPRESS_LOG=false
 Teaspoon.setup do |config|
   # Driver / Server
-  #config.driver           = "phantomjs" # available: phantomjs, selenium
-  #config.server           = nil # defaults to Rack::Server
+  #config.driver              = "phantomjs" # available: phantomjs, selenium
+  #config.server              = nil # defaults to Rack::Server
 
   # Behaviors
-  #config.server_timeout   = 20 # timeout for starting the server
-  #config.server_port      = nil # defaults to any open port unless specified
-  #config.fail_fast        = true # abort after the first failing suite
+  #config.server_timeout      = 20 # timeout for starting the server
+  #config.server_port         = nil # defaults to any open port unless specified
+  #config.fail_fast           = true # abort after the first failing suite
 
   # Output
-  #config.formatters       = "dot" # available: dot, tap, tap_y, swayze_or_oprah
-  #config.suppress_log     = false # suppress logs coming from console[log/error/debug]
-  #config.color            = true
+  #config.formatters          = "dot" # available: dot, tap, tap_y, swayze_or_oprah
+  #config.suppress_log        = false # suppress logs coming from console[log/error/debug]
+  #config.color               = true
 
   # Coverage (requires istanbul -- https://github.com/gotwarlost/istanbul)
-  #config.coverage         = true
-  #config.coverage_reports = "text,html,cobertura"
+  #config.coverage            = true
+  #config.coverage_reports    = "text,html,cobertura"
+  #config.coverage_output_dir = "coverage"
 end

--- a/lib/teaspoon/command_line.rb
+++ b/lib/teaspoon/command_line.rb
@@ -102,6 +102,10 @@ module Teaspoon
           @options[:coverage_reports] = reports
         end
 
+        parser.on("-O", "--coverage-output-dir DIR", "Specify directory where coverage reports should be generated.") do |dir|
+          @options[:coverage_output_dir] = dir
+        end
+
         parser.separator("\n  **** Utility ****\n\n")
 
         parser.on("-v", "--version", "Display the version.") do

--- a/lib/teaspoon/configuration.rb
+++ b/lib/teaspoon/configuration.rb
@@ -13,17 +13,18 @@ module Teaspoon
     @@driver_cli_options = nil
 
     # console runner specific
-    cattr_accessor :driver, :server_timeout, :server_port, :fail_fast, :formatters, :suppress_log, :color, :coverage, :coverage_reports, :server
-    @@driver             = "phantomjs"
-    @@server             = nil
-    @@server_port        = nil
-    @@server_timeout     = 20
-    @@fail_fast          = true
-    @@formatters         = "dot"
-    @@suppress_log       = false
-    @@color              = true
-    @@coverage           = false
-    @@coverage_reports   = nil
+    cattr_accessor :driver, :server_timeout, :server_port, :fail_fast, :formatters, :suppress_log, :color, :coverage, :coverage_reports, :coverage_output_dir, :server
+    @@driver              = "phantomjs"
+    @@server              = nil
+    @@server_port         = nil
+    @@server_timeout      = 20
+    @@fail_fast           = true
+    @@formatters          = "dot"
+    @@suppress_log        = false
+    @@color               = true
+    @@coverage            = false
+    @@coverage_reports    = nil
+    @@coverage_output_dir = "coverage"
 
     class Suite
       attr_accessor :matcher, :helper, :stylesheets, :javascripts, :no_coverage, :boot_partial, :js_config
@@ -87,7 +88,7 @@ module Teaspoon
       next unless ENV[directive].present?
       @@configuration.send("#{directive.downcase}=", ENV[directive] == "true")
     end
-    %w(DRIVER DRIVER_CLI_OPTIONS SERVER SERVER_TIMEOUT SERVER_PORT FORMATTERS COVERAGE_REPORTS).each do |directive|
+    %w(DRIVER DRIVER_CLI_OPTIONS SERVER SERVER_TIMEOUT SERVER_PORT FORMATTERS COVERAGE_REPORTS COVERAGE_OUTPUT_DIR).each do |directive|
       next unless ENV[directive].present?
       @@configuration.send("#{directive.downcase}=", ENV[directive])
     end

--- a/lib/teaspoon/coverage.rb
+++ b/lib/teaspoon/coverage.rb
@@ -22,7 +22,7 @@ module Teaspoon
     private
 
     def generate_report(input, format)
-      result = %x{#{executable} report #{format} #{input.shellescape}}
+      result = %x{#{executable} report #{format} #{input.shellescape} --dir #{Teaspoon.configuration.coverage_output_dir}}
       raise "Could not generate coverage report for #{format}" unless $?.exitstatus == 0
       result.gsub("Done", "").gsub("Using reporter [#{format}]", "").strip
     end

--- a/spec/teaspoon/configuration_spec.rb
+++ b/spec/teaspoon/configuration_spec.rb
@@ -61,6 +61,7 @@ describe Teaspoon::Configuration do
     expect(subject.suites).to be_a(Hash)
     expect(subject.coverage).to eq(false)
     expect(subject.coverage_reports).to eq(["text-summary"])
+    expect(subject.coverage_output_dir).to eq("coverage")
     expect(subject.server).to be_nil
   end
 

--- a/spec/teaspoon_env.rb
+++ b/spec/teaspoon_env.rb
@@ -14,19 +14,20 @@ require File.expand_path("../dummy/config/environment", __FILE__)
 # rake teaspoon DRIVER=selenium SUPPRESS_LOG=false
 Teaspoon.setup do |config|
   # Driver
-  #config.driver           = "phantomjs" # available: phantomjs, selenium
+  #config.driver              = "phantomjs" # available: phantomjs, selenium
 
   # Behaviors
-  #config.server_timeout   = 20 # timeout for starting the server
-  #config.server_port      = nil # defaults to any open port unless specified
-  #config.fail_fast        = true # abort after the first failing suite
+  #config.server_timeout      = 20 # timeout for starting the server
+  #config.server_port         = nil # defaults to any open port unless specified
+  #config.fail_fast           = true # abort after the first failing suite
 
   # Output
-  #config.formatters       = "dot" # available: dot, tap_y, swayze_or_oprah
-  #config.suppress_log     = false # suppress logs coming from console[log/error/debug]
-  #config.color            = true
+  #config.formatters          = "dot" # available: dot, tap_y, swayze_or_oprah
+  #config.suppress_log        = false # suppress logs coming from console[log/error/debug]
+  #config.color               = true
 
   # Coverage (requires istanbul -- https://github.com/gotwarlost/istanbul)
-  #config.coverage         = true
-  #config.coverage_reports = "text-summary,text,html,cobertura"
+  #config.coverage             = true
+  #config.coverage_reports     = "text-summary,text,html,cobertura"
+  #config.coverage_output_dir  = "coverage"
 end


### PR DESCRIPTION
Istambul "report" command supports a "--dir" option to specify the directory where coverage reports will be generated. 
Taking advantage of this functionality, this change adds an new configuration option "coverage_output_dir" to specify the output directory for coverage reports (defaults to "coverage").
