### PR TITLE
Convert Pathname objects to strings on suite load

### DIFF
--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -120,6 +120,7 @@ module Teaspoon
     def asset_from_file(original)
       filename = original
       Rails.application.config.assets.paths.each do |path|
+        path = path.to_s
         filename = filename.gsub(%r(^#{Regexp.escape(path)}[\/|\\]), "")
       end
       raise Teaspoon::AssetNotServable, "#{filename} is not within an asset path" if filename == original


### PR DESCRIPTION
This could be another edge case, but for some reason, when loading my test suite, I was getting a "TypeError: can't convert Pathname to String". In my efforts to debug I found that, in lib/suite.rb#asset_from_file, when it was cycling through 'path', at least one Pathname object was coming through. It seemed like an easy solution to just convert to string before attempting the gsub on the next line.
