### PR TITLE
Add ability to configure hooks.

### DIFF
--- a/app/controllers/teaspoon/spec_controller.rb
+++ b/app/controllers/teaspoon/spec_controller.rb
@@ -17,6 +17,13 @@ class Teaspoon::SpecController < ActionController::Base
     @suite = Teaspoon::Suite.new(params)
   end
 
+  def hooks
+    @suite = Teaspoon::Suite.new(params)
+    @suite.run_hooks(params[:group])
+
+    render nothing: true
+  end
+
   def fixtures
     prepend_view_path Teaspoon.configuration.root.join(Teaspoon.configuration.fixture_path)
     render "/#{params[:filename]}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Teaspoon::Engine.routes.draw do
   get "/fixtures/*filename", to: "spec#fixtures"
   get "/:suite", to: "spec#runner", defaults: { suite: "default" }
+  post "/:suite/hooks(/:group)", to: "spec#hooks", defaults: { suite: "default", group: "default" }
   root to: "spec#suites"
 end

--- a/lib/teaspoon/configuration.rb
+++ b/lib/teaspoon/configuration.rb
@@ -27,7 +27,7 @@ module Teaspoon
     @@coverage_output_dir = "coverage"
 
     class Suite
-      attr_accessor :matcher, :helper, :stylesheets, :javascripts, :no_coverage, :boot_partial, :js_config
+      attr_accessor :matcher, :helper, :stylesheets, :javascripts, :no_coverage, :boot_partial, :js_config, :hooks
 
       def initialize
         @matcher         = "{spec/javascripts,app/assets}/**/*_spec.{js,js.coffee,coffee}"
@@ -38,6 +38,8 @@ module Teaspoon
         @boot_partial    = nil
         @js_config       = {}
 
+        @hooks = Hash.new {|h, k| h[k] = [] }
+
         default = Teaspoon.configuration.suites["default"]
         self.instance_eval(&default) if default
         yield self if block_given?
@@ -46,6 +48,10 @@ module Teaspoon
       def use_require=(val) # todo: deprecated in version 0.7.4
         puts "Deprecation Notice: use_require will be removed, specify 'require_js' for config.boot_partial instead."
         self.boot_partial = 'require_js' if val
+      end
+
+      def hook(group = :default, &block)
+        @hooks[group.to_s] << block
       end
     end
 

--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -93,6 +93,12 @@ module Teaspoon
       false
     end
 
+    def run_hooks(group = :default)
+      config.hooks[group.to_s].each do |hook|
+        hook.call
+      end
+    end
+
     protected
 
     def specs

--- a/spec/features/hooks_spec.rb
+++ b/spec/features/hooks_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+require "tempfile"
+require "fileutils"
+
+feature "testing hooks in the browser" do
+  include Rack::Test::Methods
+
+  before do
+    Teaspoon.configuration.stub(:suites).and_return "before_hooks" => proc{ |suite|
+      suite.hook :before do
+        File.write('tmp/before_hook_test' , '')
+      end
+    }
+  end
+
+  let(:temp_file) { 'tmp/before_hook_test' }
+
+  def app
+    Dummy::Application
+  end
+
+  before do
+    FileUtils.mkdir 'tmp' unless File.directory?('tmp')
+    File.delete(temp_file) if File.exists?(temp_file)
+  end
+
+  scenario "gives me the expected results" do
+    expect(File.exists?(temp_file)).to eql(false)
+
+    post "/teaspoon/before_hooks/hooks/before"
+
+    expect(File.exists?(temp_file)).to eql(true)
+  end
+end
+
+feature "testing after hooks in the browser" do
+  include Rack::Test::Methods
+
+  before do
+    Teaspoon.configuration.stub(:suites).and_return "default" => proc{ |suite|
+      suite.hook :default do
+        File.write('tmp/default_hook_test', '')
+      end
+    }
+  end
+
+  let(:temp_file) { 'tmp/default_hook_test' }
+
+  def app
+    Dummy::Application
+  end
+
+  before do
+    FileUtils.mkdir 'tmp' unless File.directory?('tmp')
+    File.delete(temp_file) if File.exists?(temp_file)
+  end
+
+  scenario "gives me the expected results" do
+    expect(File.exists?(temp_file)).to eql(false)
+
+    post "/teaspoon/default/hooks"
+
+    expect(File.exists?(temp_file)).to eql(true)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,4 +17,7 @@ Dir[File.expand_path("../support/**/*.rb", __FILE__)].each { |f| require f }
 RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = false
   config.order = "random"
+
+  config.filter_run :focus => true
+  config.run_all_when_everything_filtered = true
 end

--- a/spec/teaspoon/configuration_spec.rb
+++ b/spec/teaspoon/configuration_spec.rb
@@ -76,7 +76,6 @@ describe Teaspoon::Configuration do
     subject.suite(:test_suite) { }
     expect(subject.suites["test_suite"]).to be_a(Proc)
   end
-
 end
 
 
@@ -95,4 +94,12 @@ describe Teaspoon::Configuration::Suite do
     expect(subject.helper).to eq("helper_file")
   end
 
+
+  it "allows creating hooks" do
+    expect(subject.hooks).to eq({})
+
+    subject.hook {}
+
+    expect(subject.hooks['default'].length).to eq(1)
+  end
 end

--- a/spec/teaspoon/suite_spec.rb
+++ b/spec/teaspoon/suite_spec.rb
@@ -243,4 +243,23 @@ describe Teaspoon::Suite do
       end
     end
   end
+
+  describe "#run_hooks" do
+    it "runs blocks added with hook" do
+      first_value = nil; second_value = nil
+
+      default_suite_config = proc do |suite|
+        suite.hook(:before) { first_value = true }
+        suite.hook(:before) { second_value = true }
+      end
+
+      Teaspoon.configuration.stub(:suites).and_return "default" => default_suite_config
+
+      suite = Teaspoon::Suite.new({suite: :default})
+      suite.run_hooks :before
+
+      expect(first_value).to eql(true)
+      expect(second_value).to eql(true)
+    end
+  end
 end


### PR DESCRIPTION
Adds custom callback hooks to be executed when triggered by a POST to `/:suite/hooks/:group`.

This is helpful in our application to allow better integration testing while still being able to reset the database at key intervals.

We are using the following:

``` ruby
# config/initializers/teaspoon.rb

Teaspoon.setup do |config|

  config.suite do |suite|
    suite.hook :clean do
      DatabaseCleaner.clean
    end
  end
end
```

``` javascript
// support/cleanDatabase.js (required from test_helper.js)
window.cleanDatabase = function(suite){
  if (!suite) { suite = 'default' };

  jQuery.ajax('/teaspoon/' + suite + '/hooks/clean', {
    async: false,
    type: 'POST'
  });
}
```
