### PR TITLE
istanbul can now be locally installed in a project.

### DIFF
--- a/lib/teaspoon/coverage.rb
+++ b/lib/teaspoon/coverage.rb
@@ -28,7 +28,7 @@ module Teaspoon
     end
 
     def executable
-      @executable ||= which("istanbul")
+      @executable ||= istanbul()
     end
   end
 end

--- a/lib/teaspoon/instrumentation.rb
+++ b/lib/teaspoon/instrumentation.rb
@@ -5,7 +5,7 @@ module Teaspoon
     extend Teaspoon::Utility
 
     def self.executable
-      @executable ||= which("istanbul")
+      @executable ||= istanbul()
     end
 
     def self.add?(response, env)

--- a/lib/teaspoon/utility.rb
+++ b/lib/teaspoon/utility.rb
@@ -22,5 +22,10 @@ module Teaspoon
 
       nil
     end
+
+    def istanbul()
+      # find istanbul in path or local npm install
+      which("istanbul") || (File.executable?("./node_modules/.bin/istanbul") ? "./node_modules/.bin/istanbul" : nil)
+    end
   end
 end

--- a/lib/teaspoon/version.rb
+++ b/lib/teaspoon/version.rb
@@ -1,3 +1,3 @@
 module Teaspoon
-  VERSION = "0.7.7"
+  VERSION = "0.7.8"
 end

--- a/spec/features/console_reporter_spec.rb
+++ b/spec/features/console_reporter_spec.rb
@@ -25,7 +25,7 @@ Failures:
 
   scenario "displays coverage information" do
     pending "broken with rails 4"
-    pending("needs istanbul to be installed") unless Teaspoon::Instrumentation.which('istanbul')
+    pending("needs istanbul to be installed") unless Teaspoon::Instrumentation.istanbul()
     run_simple("bundle exec teaspoon -r ../../spec/teaspoon_env --suite=default app/assets/javascripts/integration/integration_spec.coffee --coverage-reports=text", false)
 
     assert_partial_output("|   % Stmts |% Branches |   % Funcs |   % Lines |", all_output)

--- a/spec/features/instrumentation_spec.rb
+++ b/spec/features/instrumentation_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 feature "instrumenting javascript" do
 
   before do
-    pending("needs istanbul to be installed") unless Teaspoon::Instrumentation.which('istanbul')
+    pending("needs istanbul to be installed") unless Teaspoon::Instrumentation.istanbul()
   end
 
   scenario "requesting with instrument=true adds istanbul instrumentation" do

--- a/spec/teaspoon/instrumentation_spec.rb
+++ b/spec/teaspoon/instrumentation_spec.rb
@@ -12,7 +12,7 @@ describe Teaspoon::Instrumentation do
   let(:env) { {"QUERY_STRING" => "instrument=true"} }
 
   before do
-    Teaspoon::Instrumentation.stub(:which).and_return("/path/to/istanbul")
+    Teaspoon::Instrumentation.stub(:istanbul).and_return("/path/to/istanbul")
     Teaspoon::Instrumentation.instance_variable_set(:@executable, nil)
   end
 


### PR DESCRIPTION
This change allows users to install Istanbul locally to the project instead of globally to the machine. Users or build systems without root machine permissions cannot use code coverage.
