### PR TITLE
updating default chai style to be consistent with docs

### DIFF
--- a/lib/generators/teaspoon/install/templates/mocha/spec_helper.coffee
+++ b/lib/generators/teaspoon/install/templates/mocha/spec_helper.coffee
@@ -25,8 +25,8 @@
 # For more information see: http://chaijs.com/guide/styles
 # Examples:
 #
-#   window.assert = chai.assert()
-#   window.expect = chai.expect()
+#   window.assert = chai.assert
+#   window.expect = chai.expect
 #   window.should = chai.should()
 #
 # For more information: http://github.com/modeset/teaspoon


### PR DESCRIPTION
According to http://chaijs.com/, assert and expect shouldn't be called as a function. This was breaking my initial Teaspoon installation. I also updated https://github.com/modeset/teaspoon/wiki/Quick-Start-Walkthrough to reflect updated chai expect syntax (to.equal rather than toBe). Hope that helps!
