### PR TITLE
Add --timeout CLI option.

### DIFF
--- a/lib/teaspoon/command_line.rb
+++ b/lib/teaspoon/command_line.rb
@@ -58,6 +58,10 @@ module Teaspoon
           @options[:fail_fast] = bool
         end
 
+        parser.on("--timeout SECONDS", "Sets the timeout for the test suite to run.") do |seconds|
+          @options[:timeout] = seconds
+        end
+
         parser.separator("\n  **** Filtering ****\n\n")
 
         parser.on("-s", "--suite SUITE", "Focus to a specific suite.") do |suite|

--- a/lib/teaspoon/console.rb
+++ b/lib/teaspoon/console.rb
@@ -35,7 +35,7 @@ module Teaspoon
       url = url(suite)
       url += url.include?("?") ? "&" : "?"
       url += "reporter=Console"
-      driver.run_specs(suite, url, driver_cli_options)
+      driver.run_specs(suite, url, driver_cli_options, @options)
     end
 
     protected

--- a/lib/teaspoon/drivers/phantomjs_driver.rb
+++ b/lib/teaspoon/drivers/phantomjs_driver.rb
@@ -11,10 +11,10 @@ module Teaspoon
     class PhantomjsDriver < BaseDriver
       include Teaspoon::Utility
 
-      def run_specs(suite, url, cli_options = nil)
+      def run_specs(suite, url, cli_options = nil, options = nil)
         runner = Teaspoon::Runner.new(suite)
 
-        run(*cli_arguments(url, cli_options)) do |line|
+        run(*cli_arguments(url, cli_options, options)) do |line|
           runner.process(line) if line && line.strip != ""
         end
 
@@ -29,8 +29,9 @@ module Teaspoon
         }
       end
 
-      def cli_arguments(url, cli_options)
-        [cli_options.to_s.split(" "), script, url].flatten.compact
+      def cli_arguments(url, cli_options, options)
+        timeout = options && options[:timeout]
+        [cli_options.to_s.split(" "), script, url, timeout].flatten.compact
       end
 
       def executable

--- a/lib/teaspoon/drivers/selenium_driver.rb
+++ b/lib/teaspoon/drivers/selenium_driver.rb
@@ -9,13 +9,15 @@ module Teaspoon
       #       currently ignored. We use the Selenium Ruby binding, so the Selenium command-line options
       #       aren't used. There are a variety of Selenium options and browser-specific options
       #       supported by the binding that will take more thought and design to configure cleanly.
-      def run_specs(suite, url, driver_cli_options = nil)
+      def run_specs(suite, url, driver_cli_options = nil, options = nil)
         runner = Teaspoon::Runner.new(suite)
 
         driver = Selenium::WebDriver.for(:firefox)
         driver.navigate.to(url)
 
-        Selenium::WebDriver::Wait.new(timeout: 180, interval: 0.01, message: "Timed out").until do
+		timeout = options && options[:timeout].try(:to_i) || 180
+
+        Selenium::WebDriver::Wait.new(timeout: timeout, interval: 0.01, message: "Timed out").until do
           done = driver.execute_script("return window.Teaspoon && window.Teaspoon.finished")
           driver.execute_script("return window.Teaspoon && window.Teaspoon.getMessages() || []").each do |line|
             runner.process("#{line}\n")


### PR DESCRIPTION
There was no option to control the timeout of test suite run time. This is now fixed for both PhantomJS and Selenium drivers:

``` sh
teaspoon --timeout 200
```

I'm unsure if passing `options` as a third argument is the best solution. Maybe `:timeout` should be passed with `driver_cli_option instead?
