### PR TITLE
Allow customizable asset path normalization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,13 @@ end
   <b>default:</b> <code>`[%r{/lib/ruby/gems/}, %r{/vendor/assets/}, %r{/support/}, %r{/(.+)_helper.}]`</code>
 </dd>
 
+<dt> normalize_asset_path </dt><dd>
+  When using custom file-extensions you might need to supply a custom asset path normalization. If you need to match a
+  custom extension, simply supply a custom lambda/proc that returns the desired filename.<br/><br/>
+
+  <b>default:</b> <code>`filename.gsub('.erb', '').gsub(/(\.js\.coffee|\.coffee)$/, ".js")`</code>
+</dd>
+
 </dl>
 
 

--- a/lib/teaspoon/configuration.rb
+++ b/lib/teaspoon/configuration.rb
@@ -32,7 +32,7 @@ module Teaspoon
     @@lines_coverage_threshold      = nil
 
     class Suite
-      attr_accessor :matcher, :helper, :stylesheets, :javascripts, :no_coverage, :boot_partial, :js_config, :hooks
+      attr_accessor :matcher, :helper, :stylesheets, :javascripts, :no_coverage, :boot_partial, :js_config, :hooks, :normalize_asset_path
 
       def initialize
         @matcher         = "{spec/javascripts,app/assets}/**/*_spec.{js,js.coffee,coffee}"
@@ -42,6 +42,9 @@ module Teaspoon
         @no_coverage     = [%r{/lib/ruby/gems/}, %r{/vendor/assets/}, %r{/support/}, %r{/(.+)_helper.}]
         @boot_partial    = nil
         @js_config       = {}
+        @normalize_asset_path = lambda do |filename|
+          filename.gsub('.erb', '').gsub(/(\.js\.coffee|\.coffee)$/, ".js")
+        end
 
         @hooks = Hash.new {|h, k| h[k] = [] }
 
@@ -57,6 +60,10 @@ module Teaspoon
 
       def hook(group = :default, &block)
         @hooks[group.to_s] << block
+      end
+
+      def normalize_asset_path(filename)
+        @normalize_asset_path.call(filename)
       end
     end
 

--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -131,6 +131,8 @@ module Teaspoon
       end
       raise Teaspoon::AssetNotServable, "#{filename} is not within an asset path" if filename == original
       filename.gsub('.erb', '').gsub(/(\.js\.coffee|\.coffee)$/, ".js")
+      @config.normalize_asset_path(filename)
     end
+
   end
 end

--- a/spec/teaspoon/configuration_spec.rb
+++ b/spec/teaspoon/configuration_spec.rb
@@ -107,4 +107,20 @@ describe Teaspoon::Configuration::Suite do
 
     expect(subject.hooks['default'].length).to eq(1)
   end
+
+  describe "#normalize_asset_path" do
+    it "has the same current default" do
+      suite = Teaspoon::Configuration::Suite.new
+      expect(suite.normalize_asset_path('blah/something.js.erb')).to eq('blah/something.js')
+      expect(suite.normalize_asset_path('blah/something.js.coffee.erb')).to eq('blah/something.js')
+      expect(suite.normalize_asset_path('blah/something.js.coffee')).to eq('blah/something.js')
+    end
+
+    it "can accept a custom configuration" do
+      suite = Teaspoon::Configuration::Suite.new
+      suite.normalize_asset_path = lambda {|filename| filename.gsub('.erb', '').gsub(/(\.es6)$/, ".js") }
+
+      expect(suite.normalize_asset_path('blah/something.es6')).to eq('blah/something.js')
+    end
+  end
 end


### PR DESCRIPTION
We are using a custom extension which passes through a pre-processor (in our
case converting ES6 module semantics with AMD output), and need to instruct
Teaspoon to use the correct extension on the served files.
