### PR TITLE
Include relative URL root in JS setting Teaspoon.root if present.

### DIFF
--- a/app/views/teaspoon/spec/runner.html.erb
+++ b/app/views/teaspoon/spec/runner.html.erb
@@ -8,7 +8,7 @@
   <%= javascript_include_tag_for_teaspoon *@suite.core_javascripts %>
   <script type="text/javascript">
     Teaspoon.version = <%=raw Teaspoon::VERSION.inspect %>;
-    Teaspoon.root = <%=raw Teaspoon.configuration.mount_at.inspect %>;
+    Teaspoon.root = <%=raw [Teaspoon.configuration.context, Teaspoon.configuration.mount_at].join.inspect %>;
     Teaspoon.suites = <%=raw @suite.suites.to_json %>;
     Teaspoon.config = <%=raw @suite.js_config.to_json %>;
   </script>


### PR DESCRIPTION
Currently we can use Teaspoon in application deployed under custom context root (see #133) - let's say **http://localhost:3000/some-app/teaspoon/default**. However when I want to return from filtered specs, using 'Remove' link - it returns to **http://localhost:3000/teaspoon/default**, which is wrong.

Simplest solution is to alter `Teaspoon.root` in the template.

What do you think? Any idea at which level this should be tested?
