### PR TITLE
Update mocha spec_helper.js template to use the new API of chai.

### DIFF
--- a/lib/generators/teaspoon/install/templates/mocha/spec_helper.js
+++ b/lib/generators/teaspoon/install/templates/mocha/spec_helper.js
@@ -29,8 +29,8 @@
 // For more information see: http://chaijs.com/guide/styles
 // Examples:
 //
-//   window.assert = chai.assert();
-//   window.expect = chai.expect();
+//   window.assert = chai.assert;
+//   window.expect = chai.expect;
 //   window.should = chai.should();
 //
 // For more information: http://github.com/modeset/teaspoon


### PR DESCRIPTION
According to http://chaijs.com/, assert and expect shouldn't be called as a function. This was breaking initial Teaspoon installation when choose JavaScript to spec_helper.
