### PR TITLE
Removes thread check as the thread may be dead

### DIFF
--- a/lib/teaspoon/server.rb
+++ b/lib/teaspoon/server.rb
@@ -34,7 +34,6 @@ module Teaspoon
     end
 
     def responsive?
-      return false if @thread && @thread.join(0)
       TCPSocket.new("127.0.0.1", port).close
       return true
     rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH


### PR DESCRIPTION
Depending on the rack_options passed into Rack::Server the thread may not stay
running and can simply exit immediately. If that happens then this will always
return false. I doesn't seem to be necessary to check the thread status before
checking if the server is running via TCP so I've removed this check.
