### PR TITLE
Fixes problems running all tests after success

### DIFF
--- a/lib/teaspoon/console.rb
+++ b/lib/teaspoon/console.rb
@@ -4,20 +4,21 @@ require 'teaspoon/environment'
 module Teaspoon
   class Console
 
-    def initialize(options = nil, files = [])
-      @options = options || {}
+    def initialize(options = {}, files = [])
+      @options = @default_options = options || {}
       @suites = {}
-      @files = []
+      @files = @default_files = files || []
 
-      Teaspoon::Environment.load(@options)
+      Teaspoon::Environment.load(options)
 
       start_server
       resolve(files)
     end
 
     def execute(options = {}, files = [])
-      @options = @options.merge(options) if options.present?
-      resolve(files)
+      @options = @default_options.merge(options || {})
+      @files = @default_files + (files || [])
+      resolve(@files)
 
       failure_count = 0
       suites.each do |suite|
@@ -41,9 +42,8 @@ module Teaspoon
     protected
 
     def resolve(files)
-      return if files.length == 0
       @suites = {}
-      @files = files
+      return if files.length == 0
       files.uniq.each do |path|
         if result = Teaspoon::Suite.resolve_spec_for(path)
           suite = @suites[result[:suite]] ||= []


### PR DESCRIPTION
This allows the console runner to work with guard-teaspoon to allow for all tests to be re-run after a previously failing set of tests passes. I'm still not that familiar with how this was designed so I'm hoping if done the right things here. 

One thing I noticed was that it's hard for me to be sure what the intentions for various instance variables used for things like "suites", "files and "options" are. As a result I don't want to make any more changes than necessary here though, but I'd be happy to discuss how this might be made simpler and work on some more contributions to improve the integration between this and guard further.

This helps to fix https://github.com/modeset/guard-teaspoon/issues/3
