### PR TITLE
Change report QUnit version to match the currently included version, 1.12.0

### DIFF
--- a/app/assets/javascripts/teaspoon/qunit/reporters/html.coffee
+++ b/app/assets/javascripts/teaspoon/qunit/reporters/html.coffee
@@ -35,7 +35,7 @@ class Teaspoon.Reporters.HTML extends Teaspoon.Reporters.HTML
 
 
   envInfo: ->
-    "qunit 1.11.0"
+    "qunit 1.12.0"
 
 
 


### PR DESCRIPTION
Just a small change - I noticed the reporter showed a different version for QUnit than is actually being used.
