### PR TITLE
[requirejs] fix regexp for specs paths

### DIFF
--- a/app/views/teaspoon/suite/_boot_require_js.html.erb
+++ b/app/views/teaspoon/suite/_boot_require_js.html.erb
@@ -2,7 +2,7 @@
 rails_config = Rails.application.config
 require_options = {baseUrl: rails_config.assets.prefix}
 require_options.merge!(rails_config.requirejs.user_config) if rails_config.respond_to?(:requirejs)
-specs = @suite.spec_assets(false).map{ |s| "#{s.gsub(/\.js$/, "")}" }
+specs = @suite.spec_assets(false).map{ |s| "#{s.gsub(/\.js.*$/, "")}" }
 %>
 
 <%= javascript_include_tag @suite.helper %>


### PR DESCRIPTION
I am not sure if someone has tested it but it doesn't work for me. In development, my path looks like this:

```
app/assets/javascript/application.js?body=1
```

As you may see here: http://rubular.com/r/cNDqtMo50Y it doesn't match properly (you can compare with the new version: http://rubular.com/r/fhrXbcszJx)
