### PR TITLE
Cross-Platform which method do not return a directory as valid result

### DIFF
--- a/lib/teaspoon/utility.rb
+++ b/lib/teaspoon/utility.rb
@@ -10,7 +10,7 @@ module Teaspoon
       ENV["PATH"].split(File::PATH_SEPARATOR).each do |path|
         exts.each do |ext|
           exe = "#{path}/#{cmd}#{ext}"
-          return exe if File.executable?(exe)
+          return exe if File.file?(exe) && File.executable?(exe)
         end
       end
 


### PR DESCRIPTION
`File.executable?` can return true if is a directory, just verify if is a file before test is is executable.

Problem spotted on OSX (Montain Lion) with ruby 2.0.0-p247
