### PR TITLE
Load spec_helper synchronized with specs (when using AMD)

### DIFF
--- a/app/views/teaspoon/suite/_boot_require_js.html.erb
+++ b/app/views/teaspoon/suite/_boot_require_js.html.erb
@@ -3,9 +3,11 @@ rails_config = Rails.application.config
 require_options = {baseUrl: rails_config.assets.prefix}
 require_options.merge!(rails_config.requirejs.user_config) if rails_config.respond_to?(:requirejs)
 specs = @suite.spec_assets(false).map{ |s| "#{s.gsub(/\.js.*$/, "")}" }
+
+specs.each {|s| require_options['shim'][s] = [@suite.helper] }
 %>
 
-<%= javascript_include_tag @suite.helper %>
+<%= javascript_include_tag 'require' %>
 <script type="text/javascript">
   Teaspoon.onWindowLoad(function () {
     // setup the Teaspoon path prefix to load /assets


### PR DESCRIPTION
This way I can write my spec_helper as an AMD module and make sure that the spec_helper will be loaded before my specs.

I think that load requireJS is not responsability of the spec_helper. I use this boot_require_js and works fine with squire, chai and all.
