### PR TITLE
accept additional arguments in order to make guard-teaspoon work

### DIFF
--- a/lib/teaspoon/console.rb
+++ b/lib/teaspoon/console.rb
@@ -17,7 +17,7 @@ module Teaspoon
       !execute
     end
 
-    def execute(options = {})
+    def execute(options = {}, *args)
       execute_without_handling(options)
     rescue Teaspoon::Failure
       false


### PR DESCRIPTION
I get this error message when guard triggers after a file change:

```
Guard::Teaspoon failed to achieve its <run_on_changes>, exception was:
ArgumentError: wrong number of arguments (2 for 0..1)
```

Everything works if the changes in this pull request are in place.
