### PR TITLE
Removed call to non-existant (Teaspoon::SuiteHelper) helper

### DIFF
--- a/app/controllers/teaspoon/suite_controller.rb
+++ b/app/controllers/teaspoon/suite_controller.rb
@@ -1,6 +1,4 @@
 class Teaspoon::SuiteController < ActionController::Base
-  helper Teaspoon::SuiteHelper rescue nil
-
   before_filter :prepend_fixture_paths
 
   layout false


### PR DESCRIPTION
- This helper was removed in 44885ef4c22d93a3397d6668be7a47f158f555c1
- rescue nil was eating any error
