### PR TITLE
pass arguments to hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,24 @@ end
 
 You can then use the javascript `Teaspoon.hook("fixtures")` call at the beginning of a suite run or similar. All blocks that have been specified for a given hook will be called in the order they were defined.
 
+If your hook accepts arguments:
+
+```ruby
+config.suite :my_suite do |suite|
+  suite.hook :fixtures do |arguments|
+    # some code that has access to your passed in arguments
+  end
+end
+```
+
+You can then use the following javascript to call your hook with arguments:
+
+```js
+args = JSON.stringify({'hook_args': {'foo': 'bar'}})
+Teaspoon.hook('fixtures', { 'method': 'POST', 'payload': args})
+```
+*note that you must specify the HTTP verb under the `method` key and your argurments are passed as a stringied JSON document keyed by `hook_args` under the `payload` key
+
 ### Manifest Style
 
 Teaspoon is happy to look for files for you (and this is recommended), but you can disable this feature and maintain a manifest yourself. Configure the suite to not match any files, and then use your spec helper to create your manifest.
@@ -738,4 +756,3 @@ All licenses for the [bundled Javascript libraries](https://github.com/modeset/t
 
 ## Make Code Not War
 ![crest](https://secure.gravatar.com/avatar/aa8ea677b07f626479fd280049b0e19f?s=75)
-

--- a/app/assets/javascripts/teaspoon-jasmine.js
+++ b/app/assets/javascripts/teaspoon-jasmine.js
@@ -160,8 +160,7 @@
   var __slice = [].slice;
 
   Teaspoon.fixture = (function() {
-    var addContent, cleanup, create, load, loadComplete, preload, putContent, set, xhr, xhrRequest,
-      _this = this;
+    var addContent, cleanup, create, load, loadComplete, preload, putContent, set, xhr, xhrRequest;
 
     fixture.cache = {};
 
@@ -340,7 +339,7 @@
 
     return fixture;
 
-  }).call(this);
+  })();
 
 }).call(this);
 (function() {
@@ -371,6 +370,7 @@
       }
       xhr.onreadystatechange = callback;
       xhr.open(options['method'] || "GET", "" + Teaspoon.root + "/" + url, false);
+      xhr.setRequestHeader("Content-Type", "application/json");
       return xhr.send(options['payload']);
     };
     return xhrRequest("" + Teaspoon.suites.active + "/" + name, options, function() {
@@ -716,16 +716,14 @@
 
 }).call(this);
 (function() {
-  var _ref, _ref1, _ref2,
-    __hasProp = {}.hasOwnProperty,
+  var __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
   Teaspoon.Reporters.HTML.ProgressView = (function(_super) {
     __extends(ProgressView, _super);
 
     function ProgressView() {
-      _ref = ProgressView.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return ProgressView.__super__.constructor.apply(this, arguments);
     }
 
     ProgressView.create = function(displayProgress) {
@@ -756,8 +754,7 @@
     __extends(SimpleProgressView, _super);
 
     function SimpleProgressView() {
-      _ref1 = SimpleProgressView.__super__.constructor.apply(this, arguments);
-      return _ref1;
+      return SimpleProgressView.__super__.constructor.apply(this, arguments);
     }
 
     SimpleProgressView.prototype.build = function() {
@@ -779,8 +776,7 @@
     __extends(RadialProgressView, _super);
 
     function RadialProgressView() {
-      _ref2 = RadialProgressView.__super__.constructor.apply(this, arguments);
-      return _ref2;
+      return RadialProgressView.__super__.constructor.apply(this, arguments);
     }
 
     RadialProgressView.supported = !!document.createElement("canvas").getContext;
@@ -1120,16 +1116,14 @@
 
 }).call(this);
 (function() {
-  var _ref,
-    __hasProp = {}.hasOwnProperty,
+  var __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
   Teaspoon.Reporters.HTML = (function(_super) {
     __extends(HTML, _super);
 
     function HTML() {
-      _ref = HTML.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return HTML.__super__.constructor.apply(this, arguments);
     }
 
     HTML.prototype.readConfig = function() {
@@ -1150,7 +1144,7 @@
 
 }).call(this);
 (function() {
-  var env, _ref,
+  var env,
     __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
@@ -1278,54 +1272,63 @@
     __extends(fixture, _super);
 
     function fixture() {
-      _ref = fixture.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return fixture.__super__.constructor.apply(this, arguments);
     }
 
     window.fixture = fixture;
 
     fixture.load = function() {
-      var args,
-        _this = this;
+      var args;
       args = arguments;
       if (!(env.currentSuite || env.currentSpec)) {
         throw "Teaspoon can't load fixtures outside of describe.";
       }
       if (env.currentSuite) {
-        env.beforeEach(function() {
-          return fixture.__super__.constructor.load.apply(_this, args);
-        });
-        env.afterEach(function() {
-          return _this.cleanup();
-        });
+        env.beforeEach((function(_this) {
+          return function() {
+            return fixture.__super__.constructor.load.apply(_this, args);
+          };
+        })(this));
+        env.afterEach((function(_this) {
+          return function() {
+            return _this.cleanup();
+          };
+        })(this));
         return fixture.__super__.constructor.load.apply(this, arguments);
       } else {
-        env.currentSpec.after(function() {
-          return _this.cleanup();
-        });
+        env.currentSpec.after((function(_this) {
+          return function() {
+            return _this.cleanup();
+          };
+        })(this));
         return fixture.__super__.constructor.load.apply(this, arguments);
       }
     };
 
     fixture.set = function() {
-      var args,
-        _this = this;
+      var args;
       args = arguments;
       if (!(env.currentSuite || env.currentSpec)) {
         throw "Teaspoon can't load fixtures outside of describe.";
       }
       if (env.currentSuite) {
-        env.beforeEach(function() {
-          return fixture.__super__.constructor.set.apply(_this, args);
-        });
-        env.afterEach(function() {
-          return _this.cleanup();
-        });
+        env.beforeEach((function(_this) {
+          return function() {
+            return fixture.__super__.constructor.set.apply(_this, args);
+          };
+        })(this));
+        env.afterEach((function(_this) {
+          return function() {
+            return _this.cleanup();
+          };
+        })(this));
         return fixture.__super__.constructor.set.apply(this, arguments);
       } else {
-        env.currentSpec.after(function() {
-          return _this.cleanup();
-        });
+        env.currentSpec.after((function(_this) {
+          return function() {
+            return _this.cleanup();
+          };
+        })(this));
         return fixture.__super__.constructor.set.apply(this, arguments);
       }
     };

--- a/app/assets/javascripts/teaspoon-mocha.js
+++ b/app/assets/javascripts/teaspoon-mocha.js
@@ -160,8 +160,7 @@
   var __slice = [].slice;
 
   Teaspoon.fixture = (function() {
-    var addContent, cleanup, create, load, loadComplete, preload, putContent, set, xhr, xhrRequest,
-      _this = this;
+    var addContent, cleanup, create, load, loadComplete, preload, putContent, set, xhr, xhrRequest;
 
     fixture.cache = {};
 
@@ -340,7 +339,7 @@
 
     return fixture;
 
-  }).call(this);
+  })();
 
 }).call(this);
 (function() {
@@ -371,6 +370,7 @@
       }
       xhr.onreadystatechange = callback;
       xhr.open(options['method'] || "GET", "" + Teaspoon.root + "/" + url, false);
+      xhr.setRequestHeader("Content-Type", "application/json");
       return xhr.send(options['payload']);
     };
     return xhrRequest("" + Teaspoon.suites.active + "/" + name, options, function() {
@@ -716,16 +716,14 @@
 
 }).call(this);
 (function() {
-  var _ref, _ref1, _ref2,
-    __hasProp = {}.hasOwnProperty,
+  var __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
   Teaspoon.Reporters.HTML.ProgressView = (function(_super) {
     __extends(ProgressView, _super);
 
     function ProgressView() {
-      _ref = ProgressView.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return ProgressView.__super__.constructor.apply(this, arguments);
     }
 
     ProgressView.create = function(displayProgress) {
@@ -756,8 +754,7 @@
     __extends(SimpleProgressView, _super);
 
     function SimpleProgressView() {
-      _ref1 = SimpleProgressView.__super__.constructor.apply(this, arguments);
-      return _ref1;
+      return SimpleProgressView.__super__.constructor.apply(this, arguments);
     }
 
     SimpleProgressView.prototype.build = function() {
@@ -779,8 +776,7 @@
     __extends(RadialProgressView, _super);
 
     function RadialProgressView() {
-      _ref2 = RadialProgressView.__super__.constructor.apply(this, arguments);
-      return _ref2;
+      return RadialProgressView.__super__.constructor.apply(this, arguments);
     }
 
     RadialProgressView.supported = !!document.createElement("canvas").getContext;
@@ -1153,8 +1149,7 @@
 
 }).call(this);
 (function() {
-  var _ref,
-    __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
+  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
     __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
@@ -1194,8 +1189,7 @@
     __extends(SpecView, _super);
 
     function SpecView() {
-      _ref = SpecView.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return SpecView.__super__.constructor.apply(this, arguments);
     }
 
     SpecView.prototype.updateState = function(state) {
@@ -1208,7 +1202,7 @@
 
 }).call(this);
 (function() {
-  var env, _ref,
+  var env,
     __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
@@ -1312,35 +1306,36 @@
     __extends(fixture, _super);
 
     function fixture() {
-      _ref = fixture.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return fixture.__super__.constructor.apply(this, arguments);
     }
 
     window.fixture = fixture;
 
     fixture.load = function() {
-      var args,
-        _this = this;
+      var args;
       args = arguments;
       if (env.started) {
         return fixture.__super__.constructor.load.apply(this, arguments);
       } else {
-        return beforeEach(function() {
-          return fixture.__super__.constructor.load.apply(_this, args);
-        });
+        return beforeEach((function(_this) {
+          return function() {
+            return fixture.__super__.constructor.load.apply(_this, args);
+          };
+        })(this));
       }
     };
 
     fixture.set = function() {
-      var args,
-        _this = this;
+      var args;
       args = arguments;
       if (env.started) {
         return fixture.__super__.constructor.set.apply(this, arguments);
       } else {
-        return beforeEach(function() {
-          return fixture.__super__.constructor.set.apply(_this, args);
-        });
+        return beforeEach((function(_this) {
+          return function() {
+            return fixture.__super__.constructor.set.apply(_this, args);
+          };
+        })(this));
       }
     };
 

--- a/app/assets/javascripts/teaspoon-qunit.js
+++ b/app/assets/javascripts/teaspoon-qunit.js
@@ -160,8 +160,7 @@
   var __slice = [].slice;
 
   Teaspoon.fixture = (function() {
-    var addContent, cleanup, create, load, loadComplete, preload, putContent, set, xhr, xhrRequest,
-      _this = this;
+    var addContent, cleanup, create, load, loadComplete, preload, putContent, set, xhr, xhrRequest;
 
     fixture.cache = {};
 
@@ -340,7 +339,7 @@
 
     return fixture;
 
-  }).call(this);
+  })();
 
 }).call(this);
 (function() {
@@ -371,6 +370,7 @@
       }
       xhr.onreadystatechange = callback;
       xhr.open(options['method'] || "GET", "" + Teaspoon.root + "/" + url, false);
+      xhr.setRequestHeader("Content-Type", "application/json");
       return xhr.send(options['payload']);
     };
     return xhrRequest("" + Teaspoon.suites.active + "/" + name, options, function() {
@@ -716,16 +716,14 @@
 
 }).call(this);
 (function() {
-  var _ref, _ref1, _ref2,
-    __hasProp = {}.hasOwnProperty,
+  var __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
   Teaspoon.Reporters.HTML.ProgressView = (function(_super) {
     __extends(ProgressView, _super);
 
     function ProgressView() {
-      _ref = ProgressView.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return ProgressView.__super__.constructor.apply(this, arguments);
     }
 
     ProgressView.create = function(displayProgress) {
@@ -756,8 +754,7 @@
     __extends(SimpleProgressView, _super);
 
     function SimpleProgressView() {
-      _ref1 = SimpleProgressView.__super__.constructor.apply(this, arguments);
-      return _ref1;
+      return SimpleProgressView.__super__.constructor.apply(this, arguments);
     }
 
     SimpleProgressView.prototype.build = function() {
@@ -779,8 +776,7 @@
     __extends(RadialProgressView, _super);
 
     function RadialProgressView() {
-      _ref2 = RadialProgressView.__super__.constructor.apply(this, arguments);
-      return _ref2;
+      return RadialProgressView.__super__.constructor.apply(this, arguments);
     }
 
     RadialProgressView.supported = !!document.createElement("canvas").getContext;
@@ -1161,8 +1157,7 @@
 
 }).call(this);
 (function() {
-  var _ref, _ref1,
-    __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
+  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
     __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
@@ -1218,17 +1213,16 @@
     __extends(SpecView, _super);
 
     function SpecView() {
-      _ref = SpecView.__super__.constructor.apply(this, arguments);
-      return _ref;
+      return SpecView.__super__.constructor.apply(this, arguments);
     }
 
     SpecView.prototype.buildErrors = function() {
-      var div, error, html, _i, _len, _ref1;
+      var div, error, html, _i, _len, _ref;
       div = this.createEl("div");
       html = "";
-      _ref1 = this.spec.errors();
-      for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
-        error = _ref1[_i];
+      _ref = this.spec.errors();
+      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+        error = _ref[_i];
         html += "<strong>" + error.message + "</strong><br/>" + (this.htmlSafe(error.stack || "Stack trace unavailable")) + "<br/>";
       }
       div.innerHTML = html;
@@ -1257,17 +1251,16 @@
     __extends(FailureView, _super);
 
     function FailureView() {
-      _ref1 = FailureView.__super__.constructor.apply(this, arguments);
-      return _ref1;
+      return FailureView.__super__.constructor.apply(this, arguments);
     }
 
     FailureView.prototype.build = function() {
-      var error, html, _i, _len, _ref2;
+      var error, html, _i, _len, _ref;
       FailureView.__super__.build.call(this, "spec");
       html = "<h1 class=\"teaspoon-clearfix\"><a href=\"" + this.spec.link + "\">" + (this.htmlSafe(this.spec.fullDescription)) + "</a></h1>";
-      _ref2 = this.spec.errors();
-      for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
-        error = _ref2[_i];
+      _ref = this.spec.errors();
+      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+        error = _ref[_i];
         html += "<div><strong>" + error.message + "</strong><br/>" + (this.htmlSafe(error.stack || "Stack trace unavailable")) + "</div>";
       }
       return this.el.innerHTML = html;

--- a/app/assets/javascripts/teaspoon/base/hook.coffee
+++ b/app/assets/javascripts/teaspoon/base/hook.coffee
@@ -14,6 +14,7 @@ Teaspoon.hook = (name, options = {}) ->
 
     xhr.onreadystatechange = callback
     xhr.open(options['method'] || "GET", "#{Teaspoon.root}/#{url}", false)
+    xhr.setRequestHeader("Content-Type", "application/json")
     xhr.send(options['payload'])
 
   xhrRequest "#{Teaspoon.suites.active}/#{name}", options, ->

--- a/app/controllers/teaspoon/suite_controller.rb
+++ b/app/controllers/teaspoon/suite_controller.rb
@@ -12,7 +12,8 @@ class Teaspoon::SuiteController < ActionController::Base
   end
 
   def hook
-    Teaspoon::Suite.new(params).hooks[params[:hook].to_s].each { |hook| hook.call }
+    hooks = Teaspoon::Suite.new(params).hooks[params[:hook].to_s]
+    hooks.each { |hook| hook.call(params[:hook_args]) }
     render nothing: true
   end
 

--- a/spec/features/hooks_spec.rb
+++ b/spec/features/hooks_spec.rb
@@ -8,7 +8,8 @@ feature "testing hooks in the browser" do
   let(:app) { Dummy::Application }
   let(:suites) {{
     "suite1" => {block: proc{ |suite| suite.hook :before, &proc{ File.write(temp_file, "") } }},
-    "suite2" => {block: proc{ |suite| suite.hook :after, &proc{ File.write(temp_file, "") } }}
+    "suite2" => {block: proc{ |suite| suite.hook :after, &proc{ File.write(temp_file, "") } }},
+    "suite3" => {block: proc{ |suite| suite.hook :with_arguments, &proc{ |args| File.write(temp_file, args["message"]) } }},
   }}
 
   before do
@@ -44,4 +45,16 @@ feature "testing hooks in the browser" do
 
   end
 
+  describe "requesting a before hook with arguments (using POST)" do
+    let(:temp_file) { "tmp/before_hook_test" }
+    let(:message) { "Hello World" }
+    let(:params) do
+      { hook_args: { message: message } }
+    end
+
+    scenario "gives me the expected results" do
+      post("/teaspoon/suite3/with_arguments", params)
+      expect(File.open(temp_file).gets.chomp).to eq(message)
+    end
+  end
 end

--- a/spec/javascripts/teaspoon/base/teaspoon_spec.coffee
+++ b/spec/javascripts/teaspoon/base/teaspoon_spec.coffee
@@ -32,3 +32,23 @@ describe "Teaspoon", ->
     it "will execute if it should", ->
       Teaspoon.execute()
       expect(@spy).toHaveBeenCalled()
+
+  describe ".hook", ->
+
+    beforeEach ->
+      @xhr = jasmine.createSpyObj(
+        'xhr',
+        [
+          'open',
+          'setRequestHeader',
+          'send'
+        ]
+      )
+      spyOn(window, 'XMLHttpRequest').andReturn(@xhr)
+
+    it "sets XMLHttpRequest request header", ->
+      Teaspoon.hook("foo")
+      expect(@xhr.setRequestHeader).toHaveBeenCalledWith(
+        "Content-Type",
+        "application/json"
+      )


### PR DESCRIPTION
I don't know how you guys feel about this but I think it would be useful to allow arguments to be passed to user defined hooks. Eg: 

``` js
args = JSON.stringify({'hook_args': {'foo': 'bar'}})
Teaspoon.hook('my_hook', { 'method': 'POST', 'payload': args})
```
