### PR TITLE
Fix the bug where coverage isn't run from default rake task

### DIFF
--- a/lib/teaspoon/engine.rb
+++ b/lib/teaspoon/engine.rb
@@ -37,6 +37,7 @@ module Teaspoon
 
     def self.inject_instrumentation
       Sprockets::Environment.send(:include, Teaspoon::SprocketsInstrumentation)
+      Sprockets::Index.send(:include, Teaspoon::SprocketsInstrumentation)
     end
 
     def self.prepend_routes(app)


### PR DESCRIPTION
When running the default Rake task, the Sprockets environment (set in teaspoon/suite.rb) is an instance of `Sprockets::Index`, but the Instrumentation code is only included in `Sprockets::Environment`. By adding the module to both, coverage will run regardless of how it is called.
