### PR TITLE
Fix deprecation warning thrown by istanbul

### DIFF
--- a/lib/teaspoon/coverage.rb
+++ b/lib/teaspoon/coverage.rb
@@ -48,7 +48,7 @@ module Teaspoon
 
     def generate_report(input, format)
       output_path = File.join(@config.output_path, @suite_name)
-      result = %x{#{@executable} report #{format} --include=#{input.shellescape} --dir #{output_path} 2>&1}
+      result = %x{#{@executable} report --include=#{input.shellescape} --dir #{output_path} #{format} 2>&1}
       return result.gsub("Done", "").gsub("Using reporter [#{format}]", "").strip if $?.exitstatus == 0
       raise Teaspoon::DependencyFailure, "Could not generate coverage report for #{format}"
     end

--- a/spec/teaspoon/coverage_spec.rb
+++ b/spec/teaspoon/coverage_spec.rb
@@ -37,9 +37,9 @@ describe Teaspoon::Coverage do
 
     it "generates reports using istanbul and passes them to the block provided" do
       `(exit 0)`
-      html_report = "/path/to/executable report html --include=/temp_path/coverage.json --dir output/path/_suite_ 2>&1"
-      text1_report = "/path/to/executable report text --include=/temp_path/coverage.json --dir output/path/_suite_ 2>&1"
-      text2_report = "/path/to/executable report text-summary --include=/temp_path/coverage.json --dir output/path/_suite_ 2>&1"
+      html_report = "/path/to/executable report --include=/temp_path/coverage.json --dir output/path/_suite_ html 2>&1"
+      text1_report = "/path/to/executable report --include=/temp_path/coverage.json --dir output/path/_suite_ text 2>&1"
+      text2_report = "/path/to/executable report --include=/temp_path/coverage.json --dir output/path/_suite_ text-summary 2>&1"
       expect(subject).to receive(:`).with(html_report).and_return("_html_report_")
       expect(subject).to receive(:`).with(text1_report).and_return("_text1_report_")
       expect(subject).to receive(:`).with(text2_report).and_return("_text2_report_")


### PR DESCRIPTION
This commit removes old syntax of calling istanbul to generate report and updates to new syntax.
