### PR TITLE
Extended runner.js to provide further error details

### DIFF
--- a/lib/teaspoon/driver/phantomjs/runner.js
+++ b/lib/teaspoon/driver/phantomjs/runner.js
@@ -89,8 +89,32 @@
             return window.Teaspoon;
           });
           if (!(status === "success" && defined)) {
-            _this.fail("Failed to load: " + _this.url);
-            return;
+            if (status === "success") {
+              // Could not load the window.Teaspoon object from the JavaScript on the
+              // rendered page. This indicates that a problem occured. Lets therfore
+              // print the page as a failure description.
+              // Get plain text of the page, intend all lines (better readable)
+              var ind = "   ";
+              var error = _this.page.plainText.replace(/(?:\n)/g, "\n" + ind);
+              // take only first 10 lines, as they usually provide a good entry
+              // point for debugging and we should not spam our console.
+              var erroroutput = error.split("\n").slice(0, 10);
+              if (erroroutput !== error) {
+                erroroutput.push("... (further lines have been removed)");
+              }
+              var fail = [
+                "Failed to get Teaspoon result object on page: " + _this.url,
+                "The title of this page was '" + _this.page.title + "'.",
+                "",
+                erroroutput.join("\n")];
+
+              _this.fail(fail.join(" \n" + ind));
+            }
+            else {
+              // Status is not 'success'
+              _this.fail("Failed to load: " + _this.url +
+                ". Status: " + status);
+            }
           }
           _this.waitForResults();
         }


### PR DESCRIPTION
If there has been an error on the teaspoon webpage (e.g. if the Spec helper tries to require a file/folder which does not exist for some reason as an empty folder that has been removed during a CI process) which will result in a 'success' return code, but does not render the Teaspoon test page, the error description was - especially while debugging on a remote CI - not really helpful.

This commit provides additional error descriptions in this case by rendering the plain_text of the returned website into the console output, it does not modify the functionality.
