### PR TITLE
Don't log error event to console

### DIFF
--- a/app/assets/javascripts/teaspoon/teaspoon.coffee
+++ b/app/assets/javascripts/teaspoon/teaspoon.coffee
@@ -37,7 +37,7 @@ class @Teaspoon
     window.onerror = (message) ->
       originalOnError(arguments...) if originalOnError && originalOnError.call
       return if Teaspoon.started
-      Teaspoon.log JSON.stringify
+      Teaspoon.messages.push JSON.stringify
         _teaspoon: true
         type: "exception"
         message:  message

--- a/lib/teaspoon/driver/phantomjs/runner.js
+++ b/lib/teaspoon/driver/phantomjs/runner.js
@@ -59,9 +59,12 @@
       var _this = this;
       return {
         onError: function(message, trace) {
+          var started = _this.page.evaluate(function() {
+            return window.Teaspoon && window.Teaspoon.started;
+          });
           console.log(JSON.stringify({
             _teaspoon: true,
-            type: "error",
+            type: started ? "error" : "exception",
             message: message,
             trace: trace
           }));

--- a/lib/teaspoon/formatter/modules/report_module.rb
+++ b/lib/teaspoon/formatter/modules/report_module.rb
@@ -15,6 +15,8 @@ module Teaspoon
         log_line
       end
 
+      alias_method :log_exception, :log_error
+
       def log_result(result)
         log_information
         log_stats(result)

--- a/spec/javascripts/teaspoon/other/phantomjs_runner_spec.coffee
+++ b/spec/javascripts/teaspoon/other/phantomjs_runner_spec.coffee
@@ -120,6 +120,7 @@ describe "PhantomJS Runner", ->
   describe "callback method", ->
 
     beforeEach ->
+      @runner.initPage()
       @callbacks = @runner.pageCallbacks()
 
     describe "#onError", ->

--- a/spec/javascripts/teaspoon/teaspoon_spec.coffee
+++ b/spec/javascripts/teaspoon/teaspoon_spec.coffee
@@ -84,7 +84,7 @@ describe "Teaspoon", ->
 
   describe "onerror", ->
     beforeEach ->
-      @spy = spyOn(console, "log")
+      @spy = spyOn(Teaspoon.messages, "push")
       Teaspoon.started = false
 
     afterEach ->

--- a/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon-jasmine1.js
+++ b/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon-jasmine1.js
@@ -45,9 +45,9 @@
         if (Teaspoon.started) {
           return;
         }
-        return Teaspoon.log(JSON.stringify({
+        return Teaspoon.messages.push(JSON.stringify({
           _teaspoon: true,
-          type: 'exception',
+          type: "exception",
           message: message
         }));
       };
@@ -129,7 +129,7 @@
 
     Teaspoon.checkNamespace = function(root, klass) {
       var i, j, len, namespace, namespaces, scope;
-      namespaces = klass.split('.');
+      namespaces = klass.split(".");
       scope = root;
       for (i = j = 0, len = namespaces.length; j < len; i = ++j) {
         namespace = namespaces[i];

--- a/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon-jasmine2.js
+++ b/teaspoon-jasmine/lib/teaspoon/jasmine/assets/teaspoon-jasmine2.js
@@ -45,9 +45,9 @@
         if (Teaspoon.started) {
           return;
         }
-        return Teaspoon.log(JSON.stringify({
+        return Teaspoon.messages.push(JSON.stringify({
           _teaspoon: true,
-          type: 'exception',
+          type: "exception",
           message: message
         }));
       };
@@ -129,7 +129,7 @@
 
     Teaspoon.checkNamespace = function(root, klass) {
       var i, j, len, namespace, namespaces, scope;
-      namespaces = klass.split('.');
+      namespaces = klass.split(".");
       scope = root;
       for (i = j = 0, len = namespaces.length; j < len; i = ++j) {
         namespace = namespaces[i];

--- a/teaspoon-mocha/lib/teaspoon/mocha/assets/teaspoon-mocha.js
+++ b/teaspoon-mocha/lib/teaspoon/mocha/assets/teaspoon-mocha.js
@@ -45,9 +45,9 @@
         if (Teaspoon.started) {
           return;
         }
-        return Teaspoon.log(JSON.stringify({
+        return Teaspoon.messages.push(JSON.stringify({
           _teaspoon: true,
-          type: 'exception',
+          type: "exception",
           message: message
         }));
       };
@@ -129,7 +129,7 @@
 
     Teaspoon.checkNamespace = function(root, klass) {
       var i, j, len, namespace, namespaces, scope;
-      namespaces = klass.split('.');
+      namespaces = klass.split(".");
       scope = root;
       for (i = j = 0, len = namespaces.length; j < len; i = ++j) {
         namespace = namespaces[i];

--- a/teaspoon-qunit/lib/teaspoon/qunit/assets/teaspoon-qunit.js
+++ b/teaspoon-qunit/lib/teaspoon/qunit/assets/teaspoon-qunit.js
@@ -45,9 +45,9 @@
         if (Teaspoon.started) {
           return;
         }
-        return Teaspoon.log(JSON.stringify({
+        return Teaspoon.messages.push(JSON.stringify({
           _teaspoon: true,
-          type: 'exception',
+          type: "exception",
           message: message
         }));
       };
@@ -129,7 +129,7 @@
 
     Teaspoon.checkNamespace = function(root, klass) {
       var i, j, len, namespace, namespaces, scope;
-      namespaces = klass.split('.');
+      namespaces = klass.split(".");
       scope = root;
       for (i = j = 0, len = namespaces.length; j < len; i = ++j) {
         namespace = namespaces[i];


### PR DESCRIPTION
Just ran into an interesting issue: because of same origin policies, javascript errors that get caught in `onerror` won't have an error message if they happen on a JavaScript file on a different domain.

I have modified the phantomjs onerror handler to log as "exception" instead of "error" when Teaspoon hasn't started yet, so it has the same effect as the `onerror` handler, just with more info available
