### PR TITLE
Make boot partial template consistent with default

### DIFF
--- a/lib/generators/teaspoon/install/templates/_boot.html.erb
+++ b/lib/generators/teaspoon/install/templates/_boot.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_include_tag *@suite.spec_assets, debug: @suite.config.expand_assets %>
+<%= javascript_include_tag *@suite.spec_assets, debug: @suite.config.expand_assets, allow_non_precompiled: true %>
 <script type="text/javascript">
   Teaspoon.onWindowLoad(Teaspoon.execute);
 </script>


### PR DESCRIPTION
The default `_boot.html.erb` partial had an additional `allow_non_precompiled: true` option added in 1e3a22311fc505caf70e20f752a59e19a2eab9d2, but the template for the generator was not update at the same time.

When I ran `rails generate teaspoon:install --partials` and attempted to use the generated boot partial without modifications I found teaspoon was failing to load. Updating the template to match the default fixes this.