### PR TITLE
Allow client options to be passed into Jasmine

### DIFF
--- a/lib/teaspoon/driver/selenium.rb
+++ b/lib/teaspoon/driver/selenium.rb
@@ -23,7 +23,7 @@ module Teaspoon
       end
 
       def run_specs(runner, url)
-        driver = ::Selenium::WebDriver.for(driver_options[:client_driver], driver_options[:client_driver_opts])
+        driver = ::Selenium::WebDriver.for(driver_options[:client_driver], driver_options[:client_driver_opts] || {})
         driver.navigate.to(url)
 
         ::Selenium::WebDriver::Wait.new(driver_options).until do

--- a/lib/teaspoon/driver/selenium.rb
+++ b/lib/teaspoon/driver/selenium.rb
@@ -23,7 +23,7 @@ module Teaspoon
       end
 
       def run_specs(runner, url)
-        driver = ::Selenium::WebDriver.for(driver_options[:client_driver])
+        driver = ::Selenium::WebDriver.for(driver_options[:client_driver], driver_options[:client_driver_opts])
         driver.navigate.to(url)
 
         ::Selenium::WebDriver::Wait.new(driver_options).until do


### PR DESCRIPTION
This addresses https://github.com/jejacks0n/teaspoon/issues/518. Example usage in teaspoon_env.rb:

```
client = Selenium::WebDriver::Remote::Http::Default.new
client.timeout = 180 # 3 mins instead of the default 60 seconds
config.driver_options = {client_driver: :firefox, client_driver_opts: {http_client: client}}
```