### PR TITLE
Add support for 'skip_pipeline' asset option in Rails 5.1

### DIFF
--- a/lib/teaspoon/engine.rb
+++ b/lib/teaspoon/engine.rb
@@ -107,6 +107,9 @@ begin
       def javascript_include_tag(*sources)
         options = sources.extract_options!.stringify_keys
         path_options = options.extract!('protocol', 'extname', 'host').symbolize_keys
+        if ActionView.gem_version >= Gem::Version.new('5.1.0')
+          path_options.merge(options.extract!('skip_pipeline').symbolize_keys)
+        end
         path_options[:debug] = options['allow_non_precompiled']
         sources.uniq.map { |source|
           tag_options = {


### PR DESCRIPTION
`skip_pipeline` was not being passed through to `path_to_javascript` even though it's a valid option for Rails 5.1

This PR passes through `skip_pipeline` to `path_to_javascript` in Rails 5.1+