### PR TITLE
Add coffee-rails dependency

### DIFF
--- a/teaspoon.gemspec
+++ b/teaspoon.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |s|
   s.files       = Dir["{app,lib,bin}/**/*"] + ["MIT.LICENSE", "README.md", "CHANGELOG.md"]
   s.executables = ["teaspoon"]
 
+  s.add_dependency "coffee-rails", [">= 3.2.2", "< 5"]
   s.add_dependency "railties", [">= 3.2.5", "< 6"]
 end


### PR DESCRIPTION
Scaffolded Rails projects include `coffee-rails` unless they use `--skip-coffee`, but not all applications include it.

This PR makes the dependency explicit.

See #405