### PR TITLE
Compare Action View gem version in more stable way

### DIFF
--- a/lib/teaspoon/engine.rb
+++ b/lib/teaspoon/engine.rb
@@ -101,7 +101,7 @@ end
 
 begin
   require 'action_view'
-  if ActionView::VERSION::STRING >= '4.2.5'
+  if ActionView.gem_version >= Gem::Version.new('4.2.5')
     require 'action_view/helpers/asset_tag_helper'
     module ActionView::Helpers::AssetTagHelper
       def javascript_include_tag(*sources)


### PR DESCRIPTION
As soon as a `4.2.x` was released where `x >= 10` (4.2.10 was [released on 9/27](http://weblog.rubyonrails.org/2017/9/27/Rails-4-2-10-released/)), the previous way (introduced in #461) no longer works:

```ruby
$ ActionView::VERSION::STRING
# => "4.2.10"
$ ActionView::VERSION::STRING >= "4.2.5"
# => false
```

[`Gem::Version`](http://ruby-doc.org/stdlib-2.4.2/libdoc/rubygems/rdoc/Gem/Version.html) is smarter about comparing each part rather than doing straight-up string comparison.

[`ActionView.gem_version`](http://api.rubyonrails.org/v4.2.10/classes/ActionView.html#method-c-gem_version) was introduced in 4.2.0 (rails/rails#14101), so even though it isn't available in earlier versions of Rails, we're wrapped in a `begin..rescue..end` block, so that should be OK.

This should resolve https://github.com/jejacks0n/teaspoon/issues/443#issuecomment-332712695.
