### PR TITLE
Modified to work with Sprockets 4 beta 6

### DIFF
--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -64,8 +64,8 @@ module Teaspoon
       params = []
       params << "body=1" if config.expand_assets
       params << "instrument=1" if instrument_file?(asset.filename)
-      puts asset.filename
-      url = asset.filename.gsub(/^(.*?)\javascripts/, '')
+      puts asset.filename.gsub(/^(.*?)\javascripts\//, '')
+      url = asset.filename.gsub(/^(.*?)\javascripts\//, '')
       url += "?#{params.join("&")}" if params.any?
       url
     end

--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -64,7 +64,8 @@ module Teaspoon
       params = []
       params << "body=1" if config.expand_assets
       params << "instrument=1" if instrument_file?(asset.filename)
-      url = asset.filename
+      puts asset.filename
+      url = asset.filename.gsub('app/assets/javascripts/', '')
       url += "?#{params.join("&")}" if params.any?
       url
     end

--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -65,7 +65,7 @@ module Teaspoon
       params << "body=1" if config.expand_assets
       params << "instrument=1" if instrument_file?(asset.filename)
       puts asset.filename
-      url = asset.filename.gsub('app/assets/javascripts/', '')
+      url = asset.filename.gsub(/^(.*?)\javascripts/, '')
       url += "?#{params.join("&")}" if params.any?
       url
     end

--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -64,7 +64,7 @@ module Teaspoon
       params = []
       params << "body=1" if config.expand_assets
       params << "instrument=1" if instrument_file?(asset.filename)
-      url = asset.filename.gsub(/^(.*?)\javascripts\//, '')
+      url = asset.filename.gsub(%r{^(.*?)\javascripts/}, '')
       url += "?#{params.join("&")}" if params.any?
       url
     end

--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -64,7 +64,7 @@ module Teaspoon
       params = []
       params << "body=1" if config.expand_assets
       params << "instrument=1" if instrument_file?(asset.filename)
-      url = asset.logical_path
+      url = asset.filename
       url += "?#{params.join("&")}" if params.any?
       url
     end

--- a/lib/teaspoon/suite.rb
+++ b/lib/teaspoon/suite.rb
@@ -64,7 +64,6 @@ module Teaspoon
       params = []
       params << "body=1" if config.expand_assets
       params << "instrument=1" if instrument_file?(asset.filename)
-      puts asset.filename.gsub(/^(.*?)\javascripts\//, '')
       url = asset.filename.gsub(/^(.*?)\javascripts\//, '')
       url += "?#{params.join("&")}" if params.any?
       url


### PR DESCRIPTION
I was able to get Sprockets 4 beta 6 + es6 javascript files working with teaspoon by making this modification and setting `config.expand_assets = false`.

Teaspoon is using all of these and throwing errors because of them:

Has a deprecated dependency as far as I can tell (.pathname): http://www.rubydoc.info/github/sstephenson/sprockets/master/Sprockets%2FAsset:logical_path
Deprecated: http://www.rubydoc.info/github/sstephenson/sprockets/Sprockets%2FAsset%3Apathname
Deprecated: http://www.rubydoc.info/github/sstephenson/sprockets/Sprockets%2FAsset%3Ato_a

The way I modified the `suite.rb` file probably isn't ideal, but it does work for me. It would probably need to be modified if this were to merge.