### PR TITLE
Remove wildcard for teaspoon/*.js from precompile paths

### DIFF
--- a/lib/teaspoon/configuration.rb
+++ b/lib/teaspoon/configuration.rb
@@ -21,7 +21,7 @@ module Teaspoon
     @@asset_paths    = ["spec/javascripts", "spec/javascripts/stylesheets",
                         "test/javascripts", "test/javascripts/stylesheets"]
     @@fixture_paths  = ["spec/javascripts/fixtures", "test/javascripts/fixtures"]
-    @@asset_manifest = ["teaspoon.css", "teaspoon-filterer.js", "teaspoon/*.js", "support/*.js"]
+    @@asset_manifest = ["teaspoon.css", "teaspoon-filterer.js", "support/*.js"]
 
     # console runner specific
 


### PR DESCRIPTION
This PR removes `teaspoon/*.js` from the Sprockets precompile path. This was causing `assets:precompile` to fail in the absence of the `coffee-rails` gem on Sprockets 3+. As far as I can tell, all of these files are explicitly compiled into `*.js` files by the `teaspoon:*:build` Rake tasks and do not need to be used in the asset pipeline.

Fixes #405 