### PR TITLE
allow passing selenium options

### DIFF
--- a/lib/teaspoon/driver/selenium.rb
+++ b/lib/teaspoon/driver/selenium.rb
@@ -23,7 +23,10 @@ module Teaspoon
       end
 
       def run_specs(runner, url)
-        driver = ::Selenium::WebDriver.for(driver_options[:client_driver])
+        driver = ::Selenium::WebDriver.for(
+          driver_options[:client_driver],
+          **driver_options[:selenium_options].to_hash.to_options
+        )
         driver.navigate.to(url)
 
         ::Selenium::WebDriver::Wait.new(driver_options).until do
@@ -44,7 +47,8 @@ module Teaspoon
           client_driver: :firefox,
           timeout: Teaspoon.configuration.driver_timeout.to_i,
           interval: 0.01,
-          message: "Timed out"
+          message: 'Timed out',
+          selenium_options: {}
         ).merge(@options)
       end
     end

--- a/spec/teaspoon/driver/selenium_spec.rb
+++ b/spec/teaspoon/driver/selenium_spec.rb
@@ -38,7 +38,7 @@ describe Teaspoon::Driver.fetch(:selenium) do
 
   describe "#run_specs" do
     it "loads firefox for the webdriver" do
-      expect(Selenium::WebDriver).to receive(:for).with(:firefox)
+      expect(Selenium::WebDriver).to receive(:for).with(:firefox, {})
       subject.run_specs(runner, "_url_")
     end
 
@@ -53,7 +53,13 @@ describe Teaspoon::Driver.fetch(:selenium) do
     end
 
     it "waits for the specs to complete, setting the interval, timeout and message" do
-      hash = HashWithIndifferentAccess.new(client_driver: :firefox, timeout: 180, interval: 0.01, message: "Timed out")
+      hash = HashWithIndifferentAccess.new(
+        client_driver: :firefox,
+        timeout: 180,
+        interval: 0.01,
+        message: 'Timed out',
+        selenium_options: {}
+      )
       expect(Selenium::WebDriver::Wait).to receive(:new).with(hash)
       subject.run_specs(runner, "_url_")
     end


### PR DESCRIPTION
Chrome now allows headless capability, but teaspoon stood between my app and the ability to use it. Here's the fix, and this is how I use it in my `spec/teaspoon_env.rb` (I recommend adding it to the wiki):

```ruby
Teaspoon.configure do |config|
  config.driver_options = {
    client_driver: :chrome,
    selenium_options: {
      options: Selenium::WebDriver::Chrome::Options.new(args: ['headless', 'disable-gpu'])
    }
  }
end
```

To my understanding PhantomJS ceased development because of overwhelming security issues, and the fact it can be replaced by Chrome's headless capability. I think it's time to replace it with Selenium as the default driver.

* https://github.com/ariya/phantomjs/issues/15105
* https://www.infoq.com/news/2017/04/Phantomjs-future-uncertain
* https://carstenwindler.de/software-testing/phantomjs-is-discontinued/
* etc... http://lmgtfy.com/?q=phantomjs+ceased+development