### PR TITLE
Remove upper bound on railties

### DIFF
--- a/teaspoon.gemspec
+++ b/teaspoon.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.files       = Dir["{app,lib,bin}/**/*"] + ["MIT.LICENSE", "README.md", "CHANGELOG.md"]
   s.executables = ["teaspoon"]
 
-  s.add_dependency "railties", [">= 3.2.5", "< 6"]
+  s.add_dependency "railties", [">= 3.2.5", "< 7"]
 end


### PR DESCRIPTION
Railties version needs to be bumped to [6.0.0.beta1](https://rubygems.org/gems/railties/versions/6.0.0.beta1) to use teaspoon with Rails 6.

I removed the upper bound constraint altogether to be less conservative about this. If you want to be safe we could also change it to a `< 6.0` constraint.