### PR TITLE
Move inline JS to rendered files to support CSP

### DIFF
--- a/app/controllers/teaspoon/suite_controller.rb
+++ b/app/controllers/teaspoon/suite_controller.rb
@@ -16,6 +16,12 @@ class Teaspoon::SuiteController < ActionController::Base
     @suite = Teaspoon::Suite.new(params)
   end
 
+  def js
+    jstype = params.extract!(:jstype).fetch(:jstype, 'vanilla')
+    @suite = Teaspoon::Suite.new(params)
+    render "teaspoon/suite/#{jstype}", :content_type => 'application/javascript'
+  end
+
   def hook
     hooks = Teaspoon::Suite.new(params).hooks[params[:hook].to_s]
 

--- a/app/views/teaspoon/suite/_boot.html.erb
+++ b/app/views/teaspoon/suite/_boot.html.erb
@@ -1,4 +1,2 @@
 <%= javascript_include_tag *@suite.spec_assets, debug: @suite.config.expand_assets, allow_non_precompiled: true %>
-<script type="text/javascript">
-  Teaspoon.onWindowLoad(Teaspoon.execute);
-</script>
+<script src="<%= "#{Teaspoon.configuration.mount_at}/js/#{@suite.name}.vanilla.js" %>"></script>

--- a/app/views/teaspoon/suite/_boot_require_js.html.erb
+++ b/app/views/teaspoon/suite/_boot_require_js.html.erb
@@ -1,20 +1,2 @@
-<%
-rails_config = Rails.application.config
-require_options = {baseUrl: rails_config.assets.prefix}
-require_options.merge!(urlArgs: "instrument=1", waitSeconds: 0) if Teaspoon.configuration.use_coverage
-require_options.merge!(rails_config.requirejs.user_config) if rails_config.respond_to?(:requirejs)
-specs = @suite.spec_assets(false).map{ |s| "#{s.gsub(/\.js.*$/, "")}" }
-%>
-
 <%= javascript_include_tag @suite.helper %>
-<script type="text/javascript">
-  Teaspoon.onWindowLoad(function () {
-    // setup the Teaspoon path prefix to load /assets
-    require.config(<%= require_options.to_json.html_safe %>);
-
-    // require specs by striping off the .js file extension
-    require(<%= specs.to_json.html_safe %>, function() {
-      Teaspoon.execute();
-    });
-  });
-</script>
+<script src="<%= "#{Teaspoon.configuration.mount_at}/js/#{@suite.name}.require.js" %>"></script>

--- a/app/views/teaspoon/suite/config.js.erb
+++ b/app/views/teaspoon/suite/config.js.erb
@@ -1,0 +1,2 @@
+Teaspoon.version = <%= Teaspoon::VERSION.to_json.html_safe %>;
+Teaspoon.suites  = <%= {all: Teaspoon.configuration.suite_configs.keys, active: @suite.name}.to_json.html_safe %>;

--- a/app/views/teaspoon/suite/require.js.erb
+++ b/app/views/teaspoon/suite/require.js.erb
@@ -1,0 +1,17 @@
+<%
+rails_config = Rails.application.config
+require_options = {baseUrl: rails_config.assets.prefix}
+require_options.merge!(urlArgs: "instrument=1", waitSeconds: 0) if Teaspoon.configuration.use_coverage
+require_options.merge!(rails_config.requirejs.user_config) if rails_config.respond_to?(:requirejs)
+specs = @suite.spec_assets(false).map{ |s| "#{s.gsub(/\.js.*$/, "")}" }
+%>
+
+Teaspoon.onWindowLoad(function () {
+  // setup the Teaspoon path prefix to load /assets
+  require.config(<%= require_options.to_json.html_safe %>);
+
+  // require specs by striping off the .js file extension
+  require(<%= specs.to_json.html_safe %>, function() {
+    Teaspoon.execute();
+  });
+});

--- a/app/views/teaspoon/suite/show.html.erb
+++ b/app/views/teaspoon/suite/show.html.erb
@@ -7,10 +7,7 @@
 
     <%= stylesheet_link_tag *@suite.stylesheets %>
     <%= javascript_include_tag *@suite.javascripts %>
-    <script type="text/javascript">
-      Teaspoon.version = <%= Teaspoon::VERSION.to_json.html_safe %>;
-      Teaspoon.suites  = <%= {all: Teaspoon.configuration.suite_configs.keys, active: @suite.name}.to_json.html_safe %>;
-    </script>
+    <script src="<%= "#{Teaspoon.configuration.mount_at}/js/#{@suite.name}.config.js" %>"></script>
     <%= render @suite.boot_partial %>
   </head>
   <body data-no-turbolink>

--- a/app/views/teaspoon/suite/vanilla.js.erb
+++ b/app/views/teaspoon/suite/vanilla.js.erb
@@ -1,0 +1,1 @@
+Teaspoon.onWindowLoad(Teaspoon.execute);

--- a/lib/teaspoon/engine.rb
+++ b/lib/teaspoon/engine.rb
@@ -9,6 +9,7 @@ module Teaspoon
     routes do
       root to: "suite#index"
       match "/fixtures/*filename", to: "suite#fixtures", via: :get, as: "fixture"
+      match "/js/:suite.:jstype.js", to: "suite#js", via: :get, defaults: { suite: "default", jstype: "vanilla" }
       match "/:suite", to: "suite#show", via: :get, as: "suite", defaults: { suite: "default" }
       match "/:suite/:hook", to: "suite#hook", via: :post, defaults: { suite: "default", hook: "default" }
     end


### PR DESCRIPTION
As it is currently set up, if you're running Teaspoon in apps that have strong CSP settings, then all the inline JS pieces will not load causing people to be confused as to why individual tests are not running.

This patch fixes that by moving the files into their own JS files. The trick though was that we still need the suite information for the JS, so what we do here is that we add another route into the controller to custom render the JS based on the suite name (which we also use for the show view anyway).