### PR TITLE
Fix NoMethodError: undefined method `root' for Teaspoon:Module when running the console

### DIFF
--- a/lib/teaspoon/console.rb
+++ b/lib/teaspoon/console.rb
@@ -1,4 +1,5 @@
 require "teaspoon/environment"
+require "teaspoon/utility"
 
 module Teaspoon
   class Console


### PR DESCRIPTION
Commit 5b912da349a11d12ccdf1705a1aeb79e4f1e3a57 uses the utility method `Teaspoon.root` to find paths.  The console also needs access to this method or guard-teaspoon dies on boot.