### PR TITLE
Update to support Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
 before_script:
   - sh -e /etc/init.d/xvfb start
   - npm install -g istanbul
+  - npm install -g phantomjs
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 cache: bundler
 rvm:

--- a/Appraisals
+++ b/Appraisals
@@ -3,5 +3,5 @@ appraise "rails_5" do
 end
 
 appraise "rails_6" do
-  gem "rails", "6.0.0.beta3"
+  gem "rails", "6.0.0"
 end

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "6.0.0.beta3"
+gem "rails", "6.0.0"
 gem "teaspoon-jasmine", path: "../teaspoon-jasmine"
 gem "teaspoon-mocha", path: "../teaspoon-mocha"
 gem "teaspoon-qunit", path: "../teaspoon-qunit"

--- a/teaspoon-devkit.gemspec
+++ b/teaspoon-devkit.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency "aruba"
   s.add_dependency "appraisal"
   s.add_dependency "simplecov"
+  s.add_dependency "selenium-webdriver"
 
   # for local bundle installs
   s.add_dependency "jbuilder"

--- a/teaspoon-qunit/spec/console_spec.rb
+++ b/teaspoon-qunit/spec/console_spec.rb
@@ -58,7 +58,7 @@ feature "Running in the console", shell: true do
     expect(teaspoon_output).to match(expected_testing_output)
   end
 
-  xit "can display coverage information" do
+  it "can display coverage information" do
     pending("needs istanbul to be installed") unless Teaspoon::Instrumentation.executable
     run_teaspoon("--coverage=default")
 

--- a/teaspoon-qunit/spec/console_spec.rb
+++ b/teaspoon-qunit/spec/console_spec.rb
@@ -58,7 +58,7 @@ feature "Running in the console", shell: true do
     expect(teaspoon_output).to match(expected_testing_output)
   end
 
-  it "can display coverage information" do
+  xit "can display coverage information" do
     pending("needs istanbul to be installed") unless Teaspoon::Instrumentation.executable
     run_teaspoon("--coverage=default")
 


### PR DESCRIPTION
### Description

- Fix issue `Could not find Selenium Webdriver. Install the selenium-webdriver gem.`
- Fix issue `sh: 0: Can't open /etc/init.d/xvfb - The command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during .` on CI
- Add script to install `phantomjs` on CI