### PR TITLE
Add CI support for Sprockets 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,15 @@ addons:
 gemfile:
   - gemfiles/rails_5.gemfile
   - gemfiles/rails_6.gemfile
+  - gemfiles/rails_5_sprockets_4.gemfile
+  - gemfiles/rails_6_sprockets_4.gemfile
 env:
   global:
     - TRAVIS=true
-    - DISPLAY=:99.0
     - TEASPOON_DEVELOPMENT=true
+services:
+  - xvfb
 before_script:
-  - sh -e /etc/init.d/xvfb start
   - npm install -g istanbul
   - npm install -g phantomjs
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,19 @@
 appraise "rails_5" do
-  gem "rails", "< 5.2.3"
+  gem "rails", "< 6"
+  gem "sprockets", "< 4"
 end
 
 appraise "rails_6" do
-  gem "rails", "6.0.0"
+  gem "rails", "~> 6.0"
+  gem "sprockets", "< 4"
+end
+
+appraise "rails_5_sprockets_4" do
+  gem "rails", "< 6"
+  gem "sprockets", "~> 4.0"
+end
+
+appraise "rails_6_sprockets_4" do
+  gem "rails", "~> 6.0"
+  gem "sprockets", "~> 4.0"
 end

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -2,12 +2,13 @@
 
 source "https://rubygems.org"
 
-gem "rails", "< 5.2.3"
+gem "rails", "< 6"
 gem "teaspoon-jasmine", path: "../teaspoon-jasmine"
 gem "teaspoon-mocha", path: "../teaspoon-mocha"
 gem "teaspoon-qunit", path: "../teaspoon-qunit"
 gem "rubocop", require: false
 gem "rubocop-rails_config"
+gem "sprockets", "< 4"
 
 gemspec name: "teaspoon", path: "../"
 gemspec name: "teaspoon-devkit", path: "../"

--- a/gemfiles/rails_5_sprockets_4.gemfile
+++ b/gemfiles/rails_5_sprockets_4.gemfile
@@ -2,13 +2,13 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 6.0"
+gem "rails", "< 6"
 gem "teaspoon-jasmine", path: "../teaspoon-jasmine"
 gem "teaspoon-mocha", path: "../teaspoon-mocha"
 gem "teaspoon-qunit", path: "../teaspoon-qunit"
 gem "rubocop", require: false
 gem "rubocop-rails_config"
-gem "sprockets", "< 4"
+gem "sprockets", "~> 4.0"
 
 gemspec name: "teaspoon", path: "../"
 gemspec name: "teaspoon-devkit", path: "../"

--- a/gemfiles/rails_6_sprockets_4.gemfile
+++ b/gemfiles/rails_6_sprockets_4.gemfile
@@ -8,7 +8,7 @@ gem "teaspoon-mocha", path: "../teaspoon-mocha"
 gem "teaspoon-qunit", path: "../teaspoon-qunit"
 gem "rubocop", require: false
 gem "rubocop-rails_config"
-gem "sprockets", "< 4"
+gem "sprockets", "~> 4.0"
 
 gemspec name: "teaspoon", path: "../"
 gemspec name: "teaspoon-devkit", path: "../"


### PR DESCRIPTION
Additional Appraisal gemfiles are added to test against combinations of Rails 5 or Rails 6 with Sprockets 3 or 4. Also bumps Rails 5 and Rails 6 appraisals. 

Thanks for maintaining this very useful gem!