### PR TITLE
Fix coverage output path

### DIFF
--- a/lib/teaspoon/coverage.rb
+++ b/lib/teaspoon/coverage.rb
@@ -60,7 +60,7 @@ module Teaspoon
         output_path = File.join(@config.output_path, @suite_name)
         result, st =
           Open3.capture2e(
-            @executable, "report", "--include=#{input.shellescape}", "--dir #{output_path}", format
+            @executable, "report", "--include", input.shellescape, "--dir", output_path, format
           )
         return result.gsub("Done", "").gsub("Using reporter [#{format}]", "").strip if st.exitstatus.zero?
         raise Teaspoon::DependencyError.new("Unable to generate #{format} coverage report:\n#{result}")

--- a/spec/teaspoon/coverage_spec.rb
+++ b/spec/teaspoon/coverage_spec.rb
@@ -60,7 +60,7 @@ describe Teaspoon::Coverage do
 
     it "generates reports using istanbul and passes them to the block provided" do
       stub_exit_code(ExitCodes::SUCCESS)
-      base_report  = %w[/path/to/executable report --include=/temp_path/coverage.json --dir\ output/path/_suite_]
+      base_report  = %w[/path/to/executable report --include /temp_path/coverage.json --dir output/path/_suite_]
       html_report  = base_report + %w[html]
       text1_report = base_report + %w[text]
       text2_report = base_report + %w[text-summary]


### PR DESCRIPTION
The output directory argument wasn't being passed to istanbul correctly causing the coverage report to always get generated in `./coverage/` instead of what had been configured in teaspoon.

I've updated the `Open3.capture2e` call in `lib/teaspoon/coverage.rb` to pass the argument names and values separately which fixes the issue.