### PR TITLE
Update ruby_version requirement to allow ruby 3.0

### DIFF
--- a/teaspoon.gemspec
+++ b/teaspoon.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.files       = Dir["{app,lib,bin}/**/*"] + ["MIT.LICENSE", "README.md", "CHANGELOG.md"]
   s.executables = ["teaspoon"]
 
-  s.required_ruby_version = "~> 2.4"
+  s.required_ruby_version = ">= 2.4"
   s.add_dependency "railties", ">= 3.2.5"
 end


### PR DESCRIPTION
Ruby master branch recently bumped the version number to 3.0: https://github.com/ruby/ruby/commit/21c62fb670b1646c5051a46d29081523cd782f11

This is breaking our ruby-head CI.
