### PR TITLE
passing --filter="...." correctly escapes the spaces into "%20" and not "+"

### DIFF
--- a/lib/teaspoon/console.rb
+++ b/lib/teaspoon/console.rb
@@ -1,5 +1,6 @@
 require "teaspoon/environment"
 require "teaspoon/utility"
+require "erb"
 
 module Teaspoon
   class Console
@@ -108,7 +109,10 @@ module Teaspoon
 
       def filter(suite)
         parts = []
-        parts << "grep=#{CGI.escape(options[:filter])}" if options[:filter].present?
+        # Using ERB::Util.url_encode instead of CGI.escape as CGI.escape will convert
+        # the space ' ' into a '+' and not into "%20". The JS on the front end expects
+        # %20
+        parts << "grep=#{ERB::Util.url_encode(options[:filter])}" if options[:filter].present?
         (@suites[suite] || options[:files] || []).flatten.each { |file| parts << "file[]=#{CGI.escape(file)}" }
         "#{parts.join('&')}" if parts.present?
       end

--- a/teaspoon.gemspec
+++ b/teaspoon.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.4"
   s.add_dependency "railties", ">= 3.2.5"
+  s.add_dependency "erb"
   s.add_development_dependency "simplecov", "< 0.18"
 end


### PR DESCRIPTION
PR created against 1.2.2

Running teaspoon as

```bash
bundle exec teaspoon -s default --filter="ScenePointers are attached"
```

When using CGI.escape the string "ScenePointers are attached" becomes "ScenePointesr+are+attached" This is then passed as a "grep=ScenePointers+are+attached" into the url

In the JS that is running the specs in the browser the value of the grep is used to filter. We move through all the specs and encode their full name with encodeURIComponent

The result is

```javascript
encodeURIComponent("ScenePointers are added")
'ScenePointers%20are%20added'
```

This means that on the ruby side we were escaping the space " " in the urls as '+' and on the JS side we were escaping them as "%20". One of these had to change and it seems changing it on the ruby side is the right one.

There is no right way to escape. We can use 'addressable' and URI and CGI and ERB. ERB seems to be the most straightforward for this case, it also does not bring a lot of dependencies. Just one - 'cgi'.

In the same time there seems to be no method in URI or CGI or 'addressable' gem that would address this