### PR TITLE
fix instrumentation to support puma >= 6.2 (#600)

### DIFF
--- a/lib/teaspoon/instrumentation.rb
+++ b/lib/teaspoon/instrumentation.rb
@@ -35,10 +35,8 @@ module Teaspoon
 
       result = add_instrumentation(asset)
 
-      asset.instance_variable_set(:@source, result)
-      asset.instance_variable_set(:@length, headers["Content-Length"] = result.bytesize.to_s)
-
-      [status, headers, asset]
+      headers["Content-Length"] = result.bytesize.to_s
+      [status, headers, [result]]
     end
 
     protected


### PR DESCRIPTION
Tests are failing on Puma 6.2 (and newer) when instrumentation is enabled. This seems to be caused by [PR #3072](https://github.com/puma/puma/pull/3072/files) in Puma which changes how it handles responses. If the response body (3rd argument) is a file-like object, which `Asset` is, then it appears to be getting the file path and reading the original contents which then doesn't match the modified Content-Length header for the instrumented version.

This commit fixes the issue by returning the instrumented source as a string rather then the `Asset` object.