### PR TITLE
Use `exit!` instead of `exit`

### DIFF
--- a/lib/teaspoon/utility.rb
+++ b/lib/teaspoon/utility.rb
@@ -7,7 +7,7 @@ module Teaspoon
 
   def self.abort(message = nil, code = 1)
     STDOUT.print("#{message}\n") if message
-    exit(code)
+    exit!(code)
   end
 
   module Utility


### PR DESCRIPTION
We found that using `exit` here would conflict with the `debug` gem on Ruby 3.2. It would hang and never exit when tests completed, similar to this issue: https://github.com/ruby/debug/issues/336#issuecomment-968349278