### PR TITLE
fix: Use `Rackup::Server` when rack version is >= 3.0

### DIFF
--- a/lib/teaspoon/rackup_server_shim.rb
+++ b/lib/teaspoon/rackup_server_shim.rb
@@ -1,0 +1,10 @@
+require 'rack'
+require 'rackup'
+
+module Teaspoon
+	if Gem::Version.new(Rack.release) > '3.0'
+		RackupServerShim = ::Rackup::Server
+	else
+		RackupServerShim = ::Rack::Server
+  end
+end

--- a/lib/teaspoon/server.rb
+++ b/lib/teaspoon/server.rb
@@ -1,6 +1,7 @@
 require "socket"
 require "timeout"
 require "webrick"
+require_relative "rackup_server_shim"
 
 module Teaspoon
   class Server
@@ -16,7 +17,7 @@ module Teaspoon
 
       thread = Thread.new do
         disable_logging
-        server = Rack::Server.new(rack_options)
+        server = RackupServerShim.new(rack_options)
         server.start
       end
       wait_until_started(thread)

--- a/spec/teaspoon/server_spec.rb
+++ b/spec/teaspoon/server_spec.rb
@@ -20,7 +20,7 @@ describe Teaspoon::Server do
     end
 
     it "starts a rack server" do
-      expect(Rack::Server).to receive(:new).and_return(server)
+      expect(Teaspoon::RackupServerShim).to receive(:new).and_return(server)
       expect(server).to receive(:start)
 
       subject.start
@@ -41,7 +41,7 @@ describe Teaspoon::Server do
       )
     end
 
-    it "creates a Rack::Server with the correct setting" do
+    it "creates a Teaspoon::RackupServerShim with the correct setting" do
       expected_opts = {
         app: Rails.application,
         Host: subject.host,
@@ -52,7 +52,7 @@ describe Teaspoon::Server do
         server: Teaspoon.configuration.server,
         Silent: true,
       }
-      expect(Rack::Server).to receive(:new).with(expected_opts).and_return(server)
+      expect(Teaspoon::RackupServerShim).to receive(:new).with(expected_opts).and_return(server)
 
       subject.start
       @block.call

--- a/teaspoon.gemspec
+++ b/teaspoon.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.7"
   s.add_runtime_dependency "railties", ">= 5.0"
+  s.add_runtime_dependency "rackup", ">= 2.1"
   s.add_development_dependency "simplecov", "< 0.18"
   if RUBY_VERSION > "3"
     s.add_development_dependency "webrick"


### PR DESCRIPTION
In Rack 3.0 `Rack::Server` was moved to the `rackup` gem.

Addenda: I don't know how versioning works for the project, but I'd be glad to learn.